### PR TITLE
fix: pin lacework provider to the registry

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,8 +2,12 @@ terraform {
   required_version = ">= 0.12.0"
 
   required_providers {
-    aws      = "~> 2.0"
-    random   = ">= 2.1"
-    lacework = "~> 0.2"
+    aws    = "~> 2.0"
+    random = ">= 2.1"
+    time   = "~> 0.6"
+    lacework = {
+      source  = "lacework/lacework"
+      version = "~> 0.2"
+    }
   }
 }


### PR DESCRIPTION
I'm still seeing this when using Terraform 13
```
Error: Failed to install providers

Could not find required providers, but found possible alternatives:

  hashicorp/lacework -> lacework/lacework

If these suggestions look correct, upgrade your configuration with the
following command:

The following remote modules must also be upgraded for Terraform 0.13
compatibility:
- module.config at lacework/config/aws
```

This should fix the problem but we need to validate functionality for Terraform 12.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>