### PR TITLE
chore: bump required Terraform version to 0.12.26 and required version of Lacework provider to 0.3

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
     aws    = "~> 3.0"
@@ -7,7 +7,7 @@ terraform {
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.2"
+      version = "~> 0.3"
     }
   }
 }


### PR DESCRIPTION
This PR bumps the required version of Terraform 0.12.26 as we do not support prior versions, and Lacework to 0.3

Signed-off-by: Scott Ford <scott.ford@lacework.net>