### PR TITLE
chore: bump required version of TF to 0.12.31

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.31"
 
   required_providers {
     aws    = "~> 3.0"


### PR DESCRIPTION
Bump required TF version to 0.12.31 to address HCSEC-2021-12

Signed-off-by: Scott Ford <scott.ford@lacework.net>