### PR TITLE
Add control for creating and attaching policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "lacework_audit_policy_attachment" {
   count = var.create_policies ? 1 : 0
 
   role       = local.iam_role_name
-  policy_arn = aws_iam_policy.lacework_audit_policy.arn
+  policy_arn = aws_iam_policy.lacework_audit_policy[0].arn
   depends_on = [module.lacework_cfg_iam_role]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,8 @@ module "lacework_cfg_iam_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "security_audit_policy_attachment" {
+  count = var.create_policies ? 1 : 0
+
   role       = local.iam_role_name
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
   depends_on = [module.lacework_cfg_iam_role]
@@ -39,12 +41,16 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {
+  count = var.create_policies ? 1 : 0
+
   name        = local.lacework_audit_policy_name
   description = "An audit policy to allow Lacework to read configs (extends SecurityAudit)"
   policy      = data.aws_iam_policy_document.lacework_audit_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "lacework_audit_policy_attachment" {
+  count = var.create_policies ? 1 : 0
+
   role       = local.iam_role_name
   policy_arn = aws_iam_policy.lacework_audit_policy.arn
   depends_on = [module.lacework_cfg_iam_role]

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 locals {
-  iam_role_arn               = module.lacework_cfg_iam_role.created ? module.lacework_cfg_iam_role.arn : var.iam_role_arn
-  iam_role_name              = module.lacework_cfg_iam_role.created ? module.lacework_cfg_iam_role.name : var.iam_role_name
-  iam_role_external_id       = module.lacework_cfg_iam_role.created ? module.lacework_cfg_iam_role.external_id : var.iam_role_external_id
+  iam_role_arn         = module.lacework_cfg_iam_role.created ? module.lacework_cfg_iam_role.arn : var.iam_role_arn
+  iam_role_name        = module.lacework_cfg_iam_role.created ? module.lacework_cfg_iam_role.name : var.iam_role_name
+  iam_role_external_id = module.lacework_cfg_iam_role.created ? module.lacework_cfg_iam_role.external_id : var.iam_role_external_id
   lacework_audit_policy_name = (
     length(var.lacework_audit_policy_name) > 0 ? var.lacework_audit_policy_name : "lwaudit-policy-${random_id.uniq.hex}"
   )
@@ -54,7 +54,7 @@ resource "aws_iam_role_policy_attachment" "lacework_audit_policy_attachment" {
 # before trying to create the Lacework external integration
 resource "time_sleep" "wait_time" {
   create_duration = var.wait_time
-  depends_on      = [
+  depends_on = [
     aws_iam_role_policy_attachment.security_audit_policy_attachment,
     aws_iam_role_policy_attachment.lacework_audit_policy_attachment,
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -42,8 +42,8 @@ variable "lacework_integration_name" {
 }
 
 variable "lacework_audit_policy_name" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
   description = "The name of the custom audit policy (which extends SecurityAudit) to allow Lacework to read configs.  Defaults to lwaudit-policy-$${random_id.uniq.hex} when empty"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "create_policies" {
+  type        = bool
+  default     = true
+  description = "Set this to false when using a role who's policy is managed outside this module"
+}
 
 variable "use_existing_iam_role" {
   type        = bool


### PR DESCRIPTION
***Issue***:  
I am unable to use an existing role with policies managed outside of the module.  

***Description:***
By adding a new input called `create_policies` the module users can control whether the policies in the module are created an attached.  

Also ran terraform format against the two files worked it.

***Additional Info:***
`create_policies` defaults to `true` so there should be no impact to existing users.
