### PR TITLE
feat: add get-public-access-block capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 The Lacework audit policy extends the SecurityAudit policy to facilitate the reading of additional configuration resources.
 The audit policy is comprised of the following permissions:
 
-| sid                     | actions                       | resources |
-| ----------------------- | ----------------------------- | --------- |
-GetEbsEncryptionByDefault | ec2:GetEbsEncryptionByDefault | *         |
+| sid                       | actions                       | resources |
+| -----------------------   | ----------------------------- | --------- |
+| GetEbsEncryptionByDefault | ec2:GetEbsEncryptionByDefault | *         |
+| GetPublicAccessBlock      | s3:GetBucketPublicAccessBlock | *         |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 The Lacework audit policy extends the SecurityAudit policy to facilitate the reading of additional configuration resources.
 The audit policy is comprised of the following permissions:
 
-| sid                       | actions                       | resources |
-| -----------------------   | ----------------------------- | --------- |
-| GetEbsEncryptionByDefault | ec2:GetEbsEncryptionByDefault | *         |
-| GetPublicAccessBlock      | s3:GetBucketPublicAccessBlock | *         |
+| sid                        | actions                       | resources |
+| -------------------------- | ----------------------------- | --------- |
+| GetEbsEncryptionByDefault  | ec2:GetEbsEncryptionByDefault | *         |
+| GetBucketPublicAccessBlock | s3:GetBucketPublicAccessBlock | *         |

--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,12 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     actions   = ["ec2:GetEbsEncryptionByDefault"]
     resources = ["*"]
   }
+
+  statement {
+    sid       = "GetPublicAccessBlock"
+    actions   = ["s3:GetBucketPublicAccessBlock"]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   }
 
   statement {
-    sid       = "GetPublicAccessBlock"
+    sid       = "GetBucketPublicAccessBlock"
     actions   = ["s3:GetBucketPublicAccessBlock"]
     resources = ["*"]
   }


### PR DESCRIPTION

***Issue***: https://lacework.atlassian.net/browse/ALLY-763

***Description:***
In order for resource management v2 to successfully crawl resources we will need the `s3:GetBucketPublicAccessBlock` capability.  This is achieved easily by adding the capability to Lacework's Security Audit policy.

***Additional Info:***
When merging the git commit should reference JIRA ticket ALLY-763
