### PR TITLE
fix: bump aws provider min version to 3.35

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.31"
 
   required_providers {
-    aws    = "~> 3.0"
+    aws    = "~> 3.35"
     random = ">= 2.1"
     time   = "~> 0.6"
     lacework = {


### PR DESCRIPTION
***Issue***:  N/A

***Description:***
The PR https://github.com/lacework/terraform-aws-config/pull/30 introduced a new argument `tags`
in the resource `aws_iam_policy` that was introduced in the `aws` provider version [v3.35.0](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v3.35.0)
with https://github.com/hashicorp/terraform-provider-aws/pull/18276 and therefore we need to bump
the minimum version so that users don't experience this error:
```
Error: Unsupported argument

  on .terraform/modules/aws_config/main.tf line 45, in resource "aws_iam_policy" "lacework_audit_policy":
  45:   tags        = var.tags

An argument named "tags" is not expected here.
```

***Additional Info:***
Reported by internal teams.
