### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub release](https://img.shields.io/github/release/lacework/terraform-aws-config.svg)](https://github.com/lacework/terraform-aws-config/releases/)
 [![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/lacework/terraform-modules%2Ftest-compatibility?type=cf-1&key=eyJhbGciOiJIUzI1NiJ9.NWVmNTAxOGU4Y2FjOGQzYTkxYjg3ZDEx.RJ3DEzWmBXrJX7m38iExJ_ntGv4_Ip8VTa-an8gBwBo)]( https://g.codefresh.io/pipelines/edit/new/builds?id=607e25e6728f5a6fba30431b&pipeline=test-compatibility&projects=terraform-modules&projectId=607db54b728f5a5f8930405d)
 
-Terraform module for configuring an integration with Lacework and AWS for cloud resource configruation assessment.
+Terraform module for configuring an integration with Lacework and AWS for cloud resource configuration assessment.
 
 ## Inputs
 


### PR DESCRIPTION
## Summary

Just a typo that seems to have been copy/pasted in a couple of places (the repo description, and the terraform registry page unless that pulls from one of the others).

## How did you test this change?

n/a

## Issue

n/a