### PR TITLE
fix: set lacework provider to minimum version for api v2 migration

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
     time   = "~> 0.6"
     lacework = {
       source  = "lacework/lacework"
-      version = "~> 0.2"
+      version = "~> 0.25"
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Darren Murray <darren.murray@lacework.net>

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-ecr/blob/main/CONTRIBUTING.md
--->

## Summary

Set lacework provider to minimum version for api v2 migration

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://lacework.atlassian.net/browse/ALLY-1193
