### PR TITLE
feat: parameterize IAM policy attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,19 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 
 ## Inputs
 
-| Name                       | Description                                                                                                                                                         | Type          | Default          | Required |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ---------------- | :------: |
-| external_id_length         | The length of the external ID to generate. Max length is 1224. Ignored when use_existing_iam_role is set to `true`                                                  | `number`      | `16`             |    no    |
-| iam_role_arn               | The IAM role ARN is required when setting use_existing_iam_role to `true`                                                                                           | `string`      | `""`             |    no    |
-| iam_role_external_id       | The external ID configured inside the IAM role is required when setting use_existing_iam_role to `true`                                                             | `string`      | `""`             |    no    |
-| iam_role_name              | The IAM role name. Required to match with iam_role_arn if use_existing_iam_role is set to `true`                                                                    | `string`      | `""`             |    no    |
-| lacework_aws_account_id    | The Lacework AWS account that the IAM role will grant access                                                                                                        | `string`      | `"434813966438"` |    no    |
-| lacework_integration_name  | The name of the integration in Lacework                                                                                                                             | `string`      | `"TF config"`    |    no    |
-| lacework_audit_policy_name | The name of the custom audit policy (which extends SecurityAudit) to allow Lacework to read configs.  Defaults to `lwaudit-policy-${random_id.uniq.hex}` when empty | `string`      | `""`             |    no    |
-| tags                       | A map/dictionary of Tags to be assigned to created resources                                                                                                        | `map(string)` | `{}`             |    no    |
-| use_existing_iam_role      | Set this to true to use an existing IAM role                                                                                                                        | `bool`        | `false`          |    no    |
-| wait_time                  | Amount of time to wait before the next resource is provisioned                                                                                                      | `string`      | `"10s"`          |    no    |
+| Name                         | Description                                                                                                                                                         | Type          | Default          | Required |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ---------------- | :------: |
+| external_id_length           | The length of the external ID to generate. Max length is 1224. Ignored when use_existing_iam_role is set to `true`                                                  | `number`      | `16`             |    no    |
+| iam_role_arn                 | The IAM role ARN is required when setting use_existing_iam_role to `true`                                                                                           | `string`      | `""`             |    no    |
+| iam_role_external_id         | The external ID configured inside the IAM role is required when setting use_existing_iam_role to `true`                                                             | `string`      | `""`             |    no    |
+| iam_role_name                | The IAM role name. Required to match with iam_role_arn if use_existing_iam_role is set to `true`                                                                    | `string`      | `""`             |    no    |
+| lacework_aws_account_id      | The Lacework AWS account that the IAM role will grant access                                                                                                        | `string`      | `"434813966438"` |    no    |
+| lacework_integration_name    | The name of the integration in Lacework                                                                                                                             | `string`      | `"TF config"`    |    no    |
+| lacework_audit_policy_name   | The name of the custom audit policy (which extends SecurityAudit) to allow Lacework to read configs.  Defaults to `lwaudit-policy-${random_id.uniq.hex}` when empty | `string`      | `""`             |    no    |
+| tags                         | A map/dictionary of Tags to be assigned to created resources                                                                                                        | `map(string)` | `{}`             |    no    |
+| use_existing_iam_role        | Set this to true to use an existing IAM role                                                                                                                        | `bool`        | `false`          |    no    |
+| use_existing_iam_role_policy | Set this to `true` to use an existing policy on the IAM role                                                                                                        | `bool`        | `false`          |    no    |
+| wait_time                    | Amount of time to wait before the next resource is provisioned                                                                                                      | `string`      | `"10s"`          |    no    |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ module "lacework_cfg_iam_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "security_audit_policy_attachment" {
+  count      = var.use_existing_iam_role_policy ? 0 : 1
   role       = local.iam_role_name
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
   depends_on = [module.lacework_cfg_iam_role]
@@ -29,6 +30,7 @@ resource "aws_iam_role_policy_attachment" "security_audit_policy_attachment" {
 
 # Lacework custom configuration policy
 data "aws_iam_policy_document" "lacework_audit_policy" {
+  count   = var.use_existing_iam_role_policy ? 0 : 1
   version = "2012-10-17"
 
   statement {
@@ -45,15 +47,17 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {
+  count       = var.use_existing_iam_role_policy ? 0 : 1
   name        = local.lacework_audit_policy_name
   description = "An audit policy to allow Lacework to read configs (extends SecurityAudit)"
-  policy      = data.aws_iam_policy_document.lacework_audit_policy.json
+  policy      = data.aws_iam_policy_document.lacework_audit_policy[0].json
   tags        = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "lacework_audit_policy_attachment" {
+  count      = var.use_existing_iam_role_policy ? 0 : 1
   role       = local.iam_role_name
-  policy_arn = aws_iam_policy.lacework_audit_policy.arn
+  policy_arn = aws_iam_policy.lacework_audit_policy[0].arn
   depends_on = [module.lacework_cfg_iam_role]
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,12 @@ variable "use_existing_iam_role" {
   description = "Set this to true to use an existing IAM role"
 }
 
+variable "use_existing_iam_role_policy" {
+  type        = bool
+  default     = false
+  description = "Set this to `true` to use an existing policy on the IAM role, rather than attaching a new one"
+}
+
 variable "iam_role_arn" {
   type        = string
   default     = ""


### PR DESCRIPTION
## Summary

This PR adds a new `use_existing_iam_role_policy` variable which allows the user to provide us with a completely configured IAM role and associated policy - where we don't create/attach a policy to the provided IAM role.

This is necessary where IAM change control goes through a different process than infrastructure provisioning.

Changes mirror those made in a similar PR for the terraform-aws-cloudtrail module here: https://github.com/lacework/terraform-aws-cloudtrail/pull/93

## How did you test this change?

Tested changes with existing integration and it produced the following plan:

```
Terraform will perform the following actions:

  # module.aws_config.aws_iam_policy.lacework_audit_policy has moved to module.aws_config.aws_iam_policy.lacework_audit_policy[0]
    resource "aws_iam_policy" "lacework_audit_policy" {
        id          = "arn:aws:iam::975442149240:policy/lwaudit-policy-e036a4f7"
        name        = "lwaudit-policy-e036a4f7"
        tags        = {}
        # (6 unchanged attributes hidden)
    }

  # module.aws_config.aws_iam_role_policy_attachment.lacework_audit_policy_attachment has moved to module.aws_config.aws_iam_role_policy_attachment.lacework_audit_policy_attachment[0]
    resource "aws_iam_role_policy_attachment" "lacework_audit_policy_attachment" {
        id         = "lw-iam-f62a44c5-20221021200943802500000002"
        # (2 unchanged attributes hidden)
    }

  # module.aws_config.aws_iam_role_policy_attachment.security_audit_policy_attachment has moved to module.aws_config.aws_iam_role_policy_attachment.security_audit_policy_attachment[0]
    resource "aws_iam_role_policy_attachment" "security_audit_policy_attachment" {
        id         = "lw-iam-f62a44c5-20221021200943801400000001"
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.
```

After setting `use_existing_iam_role_policy = true`, the following was produced:

```
Terraform will perform the following actions:

  # module.aws_config.aws_iam_policy.lacework_audit_policy[0] will be destroyed
  # (because index [0] is out of range for count)
  # (moved from module.aws_config.aws_iam_policy.lacework_audit_policy)
  - resource "aws_iam_policy" "lacework_audit_policy" {
      - arn         = "arn:aws:iam::975442149240:policy/lwaudit-policy-e036a4f7" -> null
      - description = "An audit policy to allow Lacework to read configs (extends SecurityAudit)" -> null
      - id          = "arn:aws:iam::975442149240:policy/lwaudit-policy-e036a4f7" -> null
      - name        = "lwaudit-policy-e036a4f7" -> null
      - path        = "/" -> null
      - policy      = jsonencode(
            {
              - Statement = [
                  - {
                      - Action   = "ec2:GetEbsEncryptionByDefault"
                      - Effect   = "Allow"
                      - Resource = "*"
                      - Sid      = "GetEbsEncryptionByDefault"
                    },
                  - {
                      - Action   = "s3:GetBucketPublicAccessBlock"
                      - Effect   = "Allow"
                      - Resource = "*"
                      - Sid      = "GetBucketPublicAccessBlock"
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - policy_id   = "ANPA6GHHB754MNV7CPTCL" -> null
      - tags        = {} -> null
      - tags_all    = {} -> null
    }

  # module.aws_config.aws_iam_role_policy_attachment.lacework_audit_policy_attachment[0] will be destroyed
  # (because index [0] is out of range for count)
  # (moved from module.aws_config.aws_iam_role_policy_attachment.lacework_audit_policy_attachment)
  - resource "aws_iam_role_policy_attachment" "lacework_audit_policy_attachment" {
      - id         = "lw-iam-f62a44c5-20221021200943802500000002" -> null
      - policy_arn = "arn:aws:iam::975442149240:policy/lwaudit-policy-e036a4f7" -> null
      - role       = "lw-iam-f62a44c5" -> null
    }

  # module.aws_config.aws_iam_role_policy_attachment.security_audit_policy_attachment[0] will be destroyed
  # (because index [0] is out of range for count)
  # (moved from module.aws_config.aws_iam_role_policy_attachment.security_audit_policy_attachment)
  - resource "aws_iam_role_policy_attachment" "security_audit_policy_attachment" {
      - id         = "lw-iam-f62a44c5-20221021200943801400000001" -> null
      - policy_arn = "arn:aws:iam::aws:policy/SecurityAudit" -> null
      - role       = "lw-iam-f62a44c5" -> null
    }

  # module.aws_config.lacework_integration_aws_cfg.default will be updated in-place
  ~ resource "lacework_integration_aws_cfg" "default" {
        id                      = "LWSTEVEP_1871EEA71DA8A1D6DA741ED885A231E7D3E8DE2D7AFE4A4"
        name                    = "TF config"
        # (7 unchanged attributes hidden)

      ~ credentials {
          ~ external_id = "x=cANtUEqAsTbXRf" -> "abcdef123456"
          ~ role_arn    = "arn:aws:iam::975442149240:role/lw-iam-f62a44c5" -> "arn:aws:iam::975442149240:role/my-iam-role"
        }
    }

  # module.aws_config.module.lacework_cfg_iam_role.aws_iam_role.lacework_iam_role[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "aws_iam_role" "lacework_iam_role" {
      - arn                   = "arn:aws:iam::975442149240:role/lw-iam-f62a44c5" -> null
      - assume_role_policy    = jsonencode(
            {
              - Statement = [
                  - {
                      - Action    = "sts:AssumeRole"
                      - Condition = {
                          - StringEquals = {
                              - "sts:ExternalId" = "x=cANtUEqAsTbXRf"
                            }
                        }
                      - Effect    = "Allow"
                      - Principal = {
                          - AWS = "arn:aws:iam::434813966438:root"
                        }
                      - Sid       = ""
                    },
                ]
              - Version   = "2012-10-17"
            }
        ) -> null
      - create_date           = "2022-10-21T20:09:43Z" -> null
      - force_detach_policies = false -> null
      - id                    = "lw-iam-f62a44c5" -> null
      - managed_policy_arns   = [
          - "arn:aws:iam::975442149240:policy/lwaudit-policy-e036a4f7",
          - "arn:aws:iam::aws:policy/SecurityAudit",
        ] -> null
      - max_session_duration  = 3600 -> null
      - name                  = "lw-iam-f62a44c5" -> null
      - path                  = "/" -> null
      - tags                  = {} -> null
      - tags_all              = {} -> null
      - unique_id             = "AROA6GHHB754OSJ6DK7IJ" -> null
    }

  # module.aws_config.module.lacework_cfg_iam_role.random_string.external_id[0] will be destroyed
  # (because index [0] is out of range for count)
  - resource "random_string" "external_id" {
      - id               = "x=cANtUEqAsTbXRf" -> null
      - length           = 16 -> null
      - lower            = true -> null
      - min_lower        = 0 -> null
      - min_numeric      = 0 -> null
      - min_special      = 0 -> null
      - min_upper        = 0 -> null
      - number           = true -> null
      - numeric          = true -> null
      - override_special = "=,.@:/-" -> null
      - result           = "x=cANtUEqAsTbXRf" -> null
      - special          = true -> null
      - upper            = true -> null
    }

Plan: 0 to add, 1 to change, 5 to destroy.
```

## Issue


