### PR TITLE
feat: add permissions_boundary variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ resource "random_id" "uniq" {
 
 module "lacework_cfg_iam_role" {
   source                  = "lacework/iam-role/aws"
-  version                 = "~> 0.2"
+  version                 = "~> 0.3"
   create                  = var.use_existing_iam_role ? false : true
   iam_role_name           = var.iam_role_name
   permissions_boundary    = var.permission_boundary_arn

--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,7 @@ module "lacework_cfg_iam_role" {
   version                 = "~> 0.3"
   create                  = var.use_existing_iam_role ? false : true
   iam_role_name           = var.iam_role_name
-  permissions_boundary    = var.permission_boundary_arn
+  permission_boundary_arn = var.permission_boundary_arn
   lacework_aws_account_id = var.lacework_aws_account_id
   external_id_length      = var.external_id_length
   tags                    = var.tags

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ module "lacework_cfg_iam_role" {
   version                 = "~> 0.2"
   create                  = var.use_existing_iam_role ? false : true
   iam_role_name           = var.iam_role_name
+  permissions_boundary    = var.permission_boundary_arn
   lacework_aws_account_id = var.lacework_aws_account_id
   external_id_length      = var.external_id_length
   tags                    = var.tags

--- a/variables.tf
+++ b/variables.tf
@@ -29,6 +29,12 @@ variable "iam_role_name" {
   description = "The IAM role name. Required to match with iam_role_arn if use_existing_iam_role is set to `true`"
 }
 
+variable "permission_boundary_arn" {
+  type        = string
+  default     = null
+  description = "Optional - ARN of the policy that is used to set the permissions boundary for the role."
+}
+
 variable "external_id_length" {
   type        = number
   default     = 16


### PR DESCRIPTION
Allows to implement a set of boundaries to the role created by Lacework

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
Adding Permissions Boundary variable to provide the ability to enforce external permissions rights for the Lacework created role. Requires an already existing permissions boundary. Applying without careful consideration can forbid access to Lacework.
-->

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

<!--
  Include the link to a Jira/Github issue
-->
