### PR TITLE
feat: add ability to not create policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,8 @@ module "lacework_cfg_iam_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "security_audit_policy_attachment" {
-  count      = var.use_existing_iam_role_policy ? 0 : 1
+  count = var.create_policies && !var.use_existing_iam_role_policy ? 1 : 0
+
   role       = local.iam_role_name
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
   depends_on = [module.lacework_cfg_iam_role]
@@ -31,7 +32,8 @@ resource "aws_iam_role_policy_attachment" "security_audit_policy_attachment" {
 
 # Lacework custom configuration policy
 data "aws_iam_policy_document" "lacework_audit_policy" {
-  count   = var.use_existing_iam_role_policy ? 0 : 1
+  count = var.use_existing_iam_role_policy ? 0 : 1
+
   version = "2012-10-17"
 
   statement {
@@ -48,7 +50,8 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {
-  count       = var.use_existing_iam_role_policy ? 0 : 1
+  count = var.create_policies && !var.use_existing_iam_role_policy ? 1 : 0
+
   name        = local.lacework_audit_policy_name
   description = "An audit policy to allow Lacework to read configs (extends SecurityAudit)"
   policy      = data.aws_iam_policy_document.lacework_audit_policy[0].json
@@ -56,7 +59,8 @@ resource "aws_iam_policy" "lacework_audit_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "lacework_audit_policy_attachment" {
-  count      = var.use_existing_iam_role_policy ? 0 : 1
+  count = var.create_policies && !var.use_existing_iam_role_policy ? 1 : 0
+
   role       = local.iam_role_name
   policy_arn = aws_iam_policy.lacework_audit_policy[0].arn
   depends_on = [module.lacework_cfg_iam_role]

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
+variable "create_policies" {
+  type        = bool
+  default     = true
+  description = "Set this to false when using a role who's policy is managed outside this module"
+}
 
 variable "use_existing_iam_role" {
   type        = bool


### PR DESCRIPTION
Replaces https://github.com/lacework/terraform-aws-config/pull/29

## Thanks @rnikoopour

***Issue***:  
I am unable to use an existing role with policies managed outside of the module.  

***Description:***
By adding a new input called `create_policies` the module users can control whether the policies in the module are created an attached.  

Also ran terraform format against the two files worked it.

***Additional Info:***
`create_policies` defaults to `true` so there should be no impact to existing users.