### PR TITLE
feat: EFS audit policy permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,13 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 The Lacework audit policy extends the SecurityAudit policy to facilitate the reading of additional configuration resources.
 The audit policy is comprised of the following permissions:
 
-| sid                        | actions                       | resources |
-| -------------------------- | ----------------------------- | --------- |
-| GetEbsEncryptionByDefault  | ec2:GetEbsEncryptionByDefault | *         |
-| GetBucketPublicAccessBlock | s3:GetBucketPublicAccessBlock | *         |
+| sid                        | actions                                             | resources |
+| -------------------------- | --------------------------------------------------- | --------- |
+| GetEbsEncryptionByDefault  | ec2:GetEbsEncryptionByDefault                       | *         |
+| GetBucketPublicAccessBlock | s3:GetBucketPublicAccessBlock                       | *         |
+| EFS                        | elasticfilesystem:DescribeFileSystemPolicy          | *         |
+|                            | elasticfilesystem:DescribeLifecycleConfiguration    |           |
+|                            | elasticfilesystem:DescribeAccessPoints              |           |
+|                            | elasticfilesystem:DescribeAccountPreferences        |           |
+|                            | elasticfilesystem:DescribeBackupPolicy              |           |
+|                            | elasticfilesystem:DescribeReplicationConfigurations |           |

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,17 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     actions   = ["s3:GetBucketPublicAccessBlock"]
     resources = ["*"]
   }
+
+  statement {
+    sid       = "EFS"
+    actions   = ["elasticfilesystem:DescribeFileSystemPolicy",
+                 "elasticfilesystem:DescribeLifecycleConfiguration",
+                 "elasticfilesystem:DescribeAccessPoints",
+                 "elasticfilesystem:DescribeAccountPreferences",
+                 "elasticfilesystem:DescribeBackupPolicy",
+                 "elasticfilesystem:DescribeReplicationConfigurations"]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
## Summary

EFS permissions that are not part of the `SecurityAudit` policy.

## How did you test this change?

Local testing.  Policy documented created with EFS permissions.

## Issue

https://lacework.atlassian.net/browse/GROW-1300