### PR TITLE
feat: Add support for AWS provider 5.0

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,9 +2,18 @@ terraform {
   required_version = ">= 0.14"
 
   required_providers {
-    aws    = ">= 3.35.0, < 5.0.0"
-    random = ">= 2.1"
-    time   = "~> 0.6"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.35.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.1"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.6"
+    }
     lacework = {
       source  = "lacework/lacework"
       version = "~> 1.0"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary

We'd like to use AWS provider 5.0

Remove higher limit, as specified in [TF best practices](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#terraform-core-and-provider-versions) for this case.


## How did you test this change?

`terraform plan` for our infrastructure

```terraform
module "aws_config" {
  # source  = "lacework/config/aws"
  # version = "0.9.0"
  source = "./terraform-aws-config"

  count = module.this.enabled ? 1 : 0

  lacework_integration_name = "${module.this.tags.Name}-cfg"
  iam_role_name             = module.this.id
}
```

## Issue
Close https://github.com/lacework/terraform-aws-config/issues/63
Close https://github.com/lacework/terraform-aws-config/pull/64
