### PR TITLE
feat: Add ReadOnly access to IdentityStore APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,10 @@ The audit policy is comprised of the following permissions:
 |                            | elasticmapreduce:ListInstanceGroups                 |           |
 | SAGEMAKER                  | sagemaker:GetModelPackageGroupPolicy                | *         |
 |                            | sagemaker:GetLineageGroupPolicy                     |           |
+| IDENTITYSTORE              | identitystore:DescribeGroup                         | *         |
+|                            | identitystore:DescribeGroupMembership               |           |
+|                            | identitystore:DescribeUser                          |           |
+|                            | identitystore:ListGroupMemberships                  |           |
+|                            | identitystore:ListGroupMembershipsForMember         |           |
+|                            | identitystore:ListGroups                            |           |
+|                            | identitystore:ListUsers                             |           |

--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,18 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
                  "sagemaker:GetLineageGroupPolicy"]
     resources = ["*"]
   }
+
+  statement {
+    sid       = "IDENTITYSTORE"
+    actions   = ["identitystore:DescribeGroup",
+                 "identitystore:DescribeGroupMembership",
+                 "identitystore:DescribeUser",
+                 "identitystore:ListGroupMemberships",
+                 "identitystore:ListGroupMembershipsForMember",
+                 "identitystore:ListGroups",
+                 "identitystore:ListUsers"]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary

This adds a new statement to the Cross-Account role policy to allow ReadOnly access to AWS IdentityStore.

## How did you test this change?

CI + Policy review.

## Issue

RAIN-47731
