### PR TITLE
feat: Add ReadOnly access to SSO APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,25 +55,28 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 The Lacework audit policy extends the SecurityAudit policy to facilitate the reading of additional configuration resources.
 The audit policy is comprised of the following permissions:
 
-| sid                        | actions                                             | resources |
-| -------------------------- | --------------------------------------------------- | --------- |
-| GetEbsEncryptionByDefault  | ec2:GetEbsEncryptionByDefault                       | *         |
-| GetBucketPublicAccessBlock | s3:GetBucketPublicAccessBlock                       | *         |
-| EFS                        | elasticfilesystem:DescribeFileSystemPolicy          | *         |
-|                            | elasticfilesystem:DescribeLifecycleConfiguration    |           |
-|                            | elasticfilesystem:DescribeAccessPoints              |           |
-|                            | elasticfilesystem:DescribeAccountPreferences        |           |
-|                            | elasticfilesystem:DescribeBackupPolicy              |           |
-|                            | elasticfilesystem:DescribeReplicationConfigurations |           |
-| EMR                        | elasticmapreduce:ListBootstrapActions               | *         |
-|                            | elasticmapreduce:ListInstanceFleets                 |           |
-|                            | elasticmapreduce:ListInstanceGroups                 |           |
-| SAGEMAKER                  | sagemaker:GetModelPackageGroupPolicy                | *         |
-|                            | sagemaker:GetLineageGroupPolicy                     |           |
-| IDENTITYSTORE              | identitystore:DescribeGroup                         | *         |
-|                            | identitystore:DescribeGroupMembership               |           |
-|                            | identitystore:DescribeUser                          |           |
-|                            | identitystore:ListGroupMemberships                  |           |
-|                            | identitystore:ListGroupMembershipsForMember         |           |
-|                            | identitystore:ListGroups                            |           |
-|                            | identitystore:ListUsers                             |           |
+| sid                        | actions                                                 | resources |
+| -------------------------- | ------------------------------------------------------- | --------- |
+| GetEbsEncryptionByDefault  | ec2:GetEbsEncryptionByDefault                           | *         |
+| GetBucketPublicAccessBlock | s3:GetBucketPublicAccessBlock                           | *         |
+| EFS                        | elasticfilesystem:DescribeFileSystemPolicy              | *         |
+|                            | elasticfilesystem:DescribeLifecycleConfiguration        |           |
+|                            | elasticfilesystem:DescribeAccessPoints                  |           |
+|                            | elasticfilesystem:DescribeAccountPreferences            |           |
+|                            | elasticfilesystem:DescribeBackupPolicy                  |           |
+|                            | elasticfilesystem:DescribeReplicationConfigurations     |           |
+| EMR                        | elasticmapreduce:ListBootstrapActions                   | *         |
+|                            | elasticmapreduce:ListInstanceFleets                     |           |
+|                            | elasticmapreduce:ListInstanceGroups                     |           |
+| SAGEMAKER                  | sagemaker:GetModelPackageGroupPolicy                    | *         |
+|                            | sagemaker:GetLineageGroupPolicy                         |           |
+| IDENTITYSTORE              | identitystore:DescribeGroup                             | *         |
+|                            | identitystore:DescribeGroupMembership                   |           |
+|                            | identitystore:DescribeUser                              |           |
+|                            | identitystore:ListGroupMemberships                      |           |
+|                            | identitystore:ListGroupMembershipsForMember             |           |
+|                            | identitystore:ListGroups                                |           |
+|                            | identitystore:ListUsers                                 |           |
+| SSO                        | sso:DescribeAccountAssignmentDeletionStatus             | *         |
+|                            | sso:DescribeInstanceAccessControlAttributeConfiguration |           |
+|                            | sso:GetInlinePolicyForPermissionSet                     |           |

--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,14 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
                  "identitystore:ListUsers"]
     resources = ["*"]
   }
+
+  statement {
+    sid       = "SSO"
+    actions   = ["sso:DescribeAccountAssignmentDeletionStatus",
+                 "sso:DescribeInstanceAccessControlAttributeConfiguration",
+                 "sso:GetInlinePolicyForPermissionSet"]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
## Summary

This adds additional read-only APIs for the SSO AWS service, which are missing from the built-in AWS SecurityAudit role.

## How did you test this change?

Use an existing module, update the source to be the commit ref, apply, validate the policy contains the added actions.

## Issue

RAIN-63235
