### PR TITLE
feat(RAIN-70531): Add permission for stepfunctions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,17 @@ The audit policy is comprised of the following permissions:
 |                            | apigatewayv2:GetRouteResponses                          |           |
 |                            | apigatewayv2:GetStages                                  |           |
 |                            | apigatewayv2:GetVpcLinks                                |           |
+| STEPFUNCTIONS              | stepfunctions:ListActivities                            | *         |
+|                            | stepfunctions:ListExecutions                            |           |
+|                            | stepfunctions:ListStateMachines                         |           |
+|                            | stepfunctions:ListStateMachineVersions                  |           |
+|                            | stepfunctions:ListStateMachineAliases                   |           |
+|                            | stepfunctions:ListTagsForResource                       |           |
+|                            | stepfunctions:GetActivityTask                           |           |
+|                            | stepfunctions:GetExecutionHistory                       |           |
+|                            | stepfunctions:DescribeActivity                          |           |
+|                            | stepfunctions:DescribeExecution                         |           |
+|                            | stepfunctions:DescribeMapRun                            |           |
+|                            | stepfunctions:DescribeStateMachine                      |           |
+|                            | stepfunctions:DescribeStateMachineForExecution          |           |
+|                            | stepfunctions:DescribeStateMachineAlias                 |           |

--- a/main.tf
+++ b/main.tf
@@ -135,6 +135,26 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
       "apigatewayv2:GetVpcLinks"]
     resources = ["*"]
   }
+
+  statement {
+    sid       = "STEPFUNCTIONS"
+    actions   = ["stepfunctions:ListActivities",
+      "stepfunctions:ListExecutions",
+      "stepfunctions:ListMapRuns",
+      "stepfunctions:ListStateMachines",
+      "stepfunctions:ListStateMachineVersions",
+      "stepfunctions:ListStateMachineAliases",
+      "stepfunctions:ListTagsForResource",
+      "stepfunctions:GetActivityTask",
+      "stepfunctions:GetExecutionHistory",
+      "stepfunctions:DescribeActivity",
+      "stepfunctions:DescribeExecution",
+      "stepfunctions:DescribeMapRun",
+      "stepfunctions:DescribeStateMachine",
+      "stepfunctions:DescribeStateMachineForExecution",
+      "stepfunctions:DescribeStateMachineAlias",]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
stepfunctions doesn't have permissions in security audit. 


## How did you test this change?
Testing it in dev8 terraform

## Issue
https://lacework.atlassian.net/browse/RAIN-70394