### PR TITLE
feat(RAIN-46933): Add permission for service DocumentDb

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,20 @@ The audit policy is comprised of the following permissions:
 |                            | stepfunctions:DescribeStateMachine                      |           |
 |                            | stepfunctions:DescribeStateMachineForExecution          |           |
 |                            | stepfunctions:DescribeStateMachineAlias                 |           |
+| DOCDB                      | docdb:DescribeCertificates                              |           |
+|                            | docdb:DescribeDbClusterParameterGroups                  |           |
+|                            | docdb:DescribeDbClusterParameters                       |           |
+|                            | docdb:DescribeDbClusterSnapshotAttributes               |           |
+|                            | docdb:DescribeDbClusterSnapshots                        |           |
+|                            | docdb:DescribeDbClusters                                |           |
+|                            | docdb:DescribeDbEngineVersions                          |           |
+|                            | docdb:DescribeDbInstances                               |           |
+|                            | docdb:DescribeDbSubnetGroups                            |           |
+|                            | docdb:DescribeEngineDefaultClusterParameters            |           |
+|                            | docdb:DescribeEventCategories                           |           |
+|                            | docdb:DescribeEventSubscriptions                        |           |
+|                            | docdb:DescribeEvents                                    |           |
+|                            | docdb:DescribeGlobalClusters                            |           |
+|                            | docdb:DescribeOrderableDbInstanceOptions                |           |
+|                            | docdb:DescribePendingMaintenanceActions                 |           |
+|                            | docdb:ListTagsForResource                               |           |            

--- a/main.tf
+++ b/main.tf
@@ -155,6 +155,29 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
       "stepfunctions:DescribeStateMachineAlias",]
     resources = ["*"]
   }
+
+  statement {
+    sid       = "DOCDB"
+    actions   = [
+      "docdb:DescribeCertificates",
+      "docdb:DescribeDbClusterParameterGroups",
+      "docdb:DescribeDbClusterParameters",
+      "docdb:DescribeDbClusterSnapshotAttributes",
+      "docdb:DescribeDbClusterSnapshots",
+      "docdb:DescribeDbClusters",
+      "docdb:DescribeDbEngineVersions",
+      "docdb:DescribeDbInstances",
+      "docdb:DescribeDbSubnetGroups",
+      "docdb:DescribeEngineDefaultClusterParameters",
+      "docdb:DescribeEventCategories",
+      "docdb:DescribeEventSubscriptions",
+      "docdb:DescribeEvents",
+      "docdb:DescribeGlobalClusters",
+      "docdb:DescribeOrderableDbInstanceOptions",
+      "docdb:DescribePendingMaintenanceActions",
+      "docdb:ListTagsForResource",]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION

## Summary
There is no permission for aws service documentdb
https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/SecurityAudit$jsonEditor
This PR adds the permission for it.

## How did you test this change?
testing it in dev8

## Issue
https://lacework.atlassian.net/browse/RAIN-46933?atlOrigin=eyJpIjoiZjQ0NjYzODY2ZGFiNDVkMmE1ZDk4ODIyMmY5MGJhYWIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ