### PR TITLE
chore: update `time` provider to `~> 0.7`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.35.0 |
 | <a name="requirement_lacework"></a> [lacework](#requirement\_lacework) | ~> 1.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.1 |
-| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.6 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | ~> 0.7 |
 
 ## Providers
 
@@ -25,7 +25,7 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.35.0 |
 | <a name="provider_lacework"></a> [lacework](#provider\_lacework) | ~> 1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.1 |
-| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.6 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.7 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -46,54 +46,54 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   }
 
   statement {
-    sid       = "EFS"
-    actions   = ["elasticfilesystem:DescribeFileSystemPolicy",
-                 "elasticfilesystem:DescribeLifecycleConfiguration",
-                 "elasticfilesystem:DescribeAccessPoints",
-                 "elasticfilesystem:DescribeAccountPreferences",
-                 "elasticfilesystem:DescribeBackupPolicy",
-                 "elasticfilesystem:DescribeReplicationConfigurations"]
+    sid = "EFS"
+    actions = ["elasticfilesystem:DescribeFileSystemPolicy",
+      "elasticfilesystem:DescribeLifecycleConfiguration",
+      "elasticfilesystem:DescribeAccessPoints",
+      "elasticfilesystem:DescribeAccountPreferences",
+      "elasticfilesystem:DescribeBackupPolicy",
+    "elasticfilesystem:DescribeReplicationConfigurations"]
     resources = ["*"]
   }
 
   statement {
-    sid       = "EMR"
-    actions   = ["elasticmapreduce:ListBootstrapActions",
-               "elasticmapreduce:ListInstanceFleets",
-               "elasticmapreduce:ListInstanceGroups"]
+    sid = "EMR"
+    actions = ["elasticmapreduce:ListBootstrapActions",
+      "elasticmapreduce:ListInstanceFleets",
+    "elasticmapreduce:ListInstanceGroups"]
     resources = ["*"]
   }
 
   statement {
-    sid       = "SAGEMAKER"
-    actions   = ["sagemaker:GetModelPackageGroupPolicy",
-                 "sagemaker:GetLineageGroupPolicy"]
+    sid = "SAGEMAKER"
+    actions = ["sagemaker:GetModelPackageGroupPolicy",
+    "sagemaker:GetLineageGroupPolicy"]
     resources = ["*"]
   }
 
   statement {
-    sid       = "IDENTITYSTORE"
-    actions   = ["identitystore:DescribeGroup",
-                 "identitystore:DescribeGroupMembership",
-                 "identitystore:DescribeUser",
-                 "identitystore:ListGroupMemberships",
-                 "identitystore:ListGroupMembershipsForMember",
-                 "identitystore:ListGroups",
-                 "identitystore:ListUsers"]
+    sid = "IDENTITYSTORE"
+    actions = ["identitystore:DescribeGroup",
+      "identitystore:DescribeGroupMembership",
+      "identitystore:DescribeUser",
+      "identitystore:ListGroupMemberships",
+      "identitystore:ListGroupMembershipsForMember",
+      "identitystore:ListGroups",
+    "identitystore:ListUsers"]
     resources = ["*"]
   }
 
   statement {
-    sid       = "SSO"
-    actions   = ["sso:DescribeAccountAssignmentDeletionStatus",
-                 "sso:DescribeInstanceAccessControlAttributeConfiguration",
-                 "sso:GetInlinePolicyForPermissionSet"]
+    sid = "SSO"
+    actions = ["sso:DescribeAccountAssignmentDeletionStatus",
+      "sso:DescribeInstanceAccessControlAttributeConfiguration",
+    "sso:GetInlinePolicyForPermissionSet"]
     resources = ["*"]
   }
 
   statement {
-    sid       = "APIGATEWAY"
-    actions   = ["apigateway:GetApiKeys",
+    sid = "APIGATEWAY"
+    actions = ["apigateway:GetApiKeys",
       "apigateway:GetAuthorizers",
       "apigateway:GetBasePathMappings",
       "apigateway:GetClientCertificates",
@@ -113,13 +113,13 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
       "apigateway:GetTags",
       "apigateway:GetUsagePlanKeys",
       "apigateway:GetUsagePlans",
-      "apigateway:GetVpcLinks"]
+    "apigateway:GetVpcLinks"]
     resources = ["*"]
   }
 
   statement {
-    sid       = "APIGATEWAYV2"
-    actions   = ["apigatewayv2:GetApis",
+    sid = "APIGATEWAYV2"
+    actions = ["apigatewayv2:GetApis",
       "apigatewayv2:GetApiMappings",
       "apigatewayv2:GetAuthorizers",
       "apigatewayv2:GetDeployments",
@@ -131,7 +131,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
       "apigatewayv2:GetRoute",
       "apigatewayv2:GetRouteResponses",
       "apigatewayv2:GetStages",
-      "apigatewayv2:GetVpcLinks"]
+    "apigatewayv2:GetVpcLinks"]
     resources = ["*"]
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.6"
+      version = "~> 0.7"
     }
     lacework = {
       source  = "lacework/lacework"


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

I have an M1 Mac, and when I try to `init` my configuration that calls on this module (the latest stable, version 0.13.0), I get the error message

```
╷
│ Error: Required plugins are not installed
│ 
│ The installed provider plugins are not consistent with the packages
│ selected in the dependency lock file:
│   - registry.terraform.io/hashicorp/time: there is no package for registry.terraform.io/hashicorp/time 0.6.0 cached in .terraform/providers
│ 
```

This is because the `time` provider version 0.6.0 does not have a binary for my platform (`darwin_arm64`). The version 0.7.x does: https://github.com/hashicorp/terraform-provider-time/releases

**Also note:** I ran `terraform fmt` in the root directory, and that change is reflected in a `chore` commit in this branch.

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

I ran `terraform init` when my configuration was 

```hcl
module "aws_config" {
  source  = "lacework/config/aws"
  version = "0.13.0"
}
```

and it failed. Then I ran `init -upgrade` when my configuration 

```hcl
module "aws_config" {
  source = "git@github.com:OpenSesame/terraform-aws-config.git/?ref=feature/DEVO-5179/time-outdated"
}
```

and it inited fine. A subsequent `plan` showed no changes.

## Issue

<!--
  Include the link to a Jira/Github issue
-->
