### PR TITLE
feat(RAIN-80724): Add permissions for ListBuilds and BatchGetBuilds

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,5 @@ The audit policy is comprised of the following permissions:
 |                            | apigatewayv2:GetRouteResponses                          |           |
 |                            | apigatewayv2:GetStages                                  |           |
 |                            | apigatewayv2:GetVpcLinks                                |           |
+| CODEBUILD                  | codebuild:ListBuilds                                    | *         |
+|                            | codebuild:BatchGetBuilds                                |           |

--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,14 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     "apigatewayv2:GetVpcLinks"]
     resources = ["*"]
   }
+
+  statement {
+    sid = "CODEBUILD"
+    actions = ["codebuild:ListBuilds",
+      "codebuild:BatchGetBuilds",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary
In https://lacework.atlassian.net/browse/RAIN-46948, ListBuilds and BatchGetBuilds are required. 
But we don't have permission for these two APIs. 

## How did you test this change?
1. Without this change, do crawling in dev8, then, I got below error with the query.
```
select distinct status
from config_preview_status_t where service='codebuild' and request_guid ='df77bf47-b2fe-483e-a9bb-e6d2553cd00c'
```
![Screenshot 2023-10-31 at 10 30 43 AM](https://github.com/lacework/terraform-aws-config/assets/5186558/1fdfc5c6-9734-4817-be3e-1142b2291d69)
2. With this change, do crawling in dev8, the error is gone.
Query is below
```
select distinct status
from config_preview_status_t where service='codebuild' and request_guid ='df77bf47-b2fe-483e-a9bb-e6d2553cd00c'
```
The result is:
![Screenshot 2023-10-31 at 10 32 07 AM](https://github.com/lacework/terraform-aws-config/assets/5186558/2e687620-a964-40f1-b948-101e594e5b28)


## Issue

<!--
  Include the link to a Jira/Github issue
-->
