### PR TITLE
feat(RAIN-90870): Add permission for five waf-regional APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,8 @@ The audit policy is comprised of the following permissions:
 |                            | apigatewayv2:GetRouteResponses                          |           |
 |                            | apigatewayv2:GetStages                                  |           |
 |                            | apigatewayv2:GetVpcLinks                                |           |
+| WAF-REGIONAL               | waf-regional:ListRules                                  | *         |
+|                            | waf-regional:GetRule                                    |           |
+|                            | waf-regional:ListRuleGroups                             |           |
+|                            | waf-regional:GetRuleGroup                               |           |
+|                            | waf-regional:ListActivatedRuleInRuleGroup               |           |

--- a/README.md
+++ b/README.md
@@ -139,4 +139,4 @@ The audit policy is comprised of the following permissions:
 |                            | waf-regional:GetRule                                    |           |
 |                            | waf-regional:ListRuleGroups                             |           |
 |                            | waf-regional:GetRuleGroup                               |           |
-|                            | waf-regional:ListActivatedRuleInRuleGroup               |           |
+|                            | waf-regional:ListActivatedRulesInRuleGroup              |           |

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The audit policy is comprised of the following permissions:
 |                            | apigatewayv2:GetRouteResponses                          |           |
 |                            | apigatewayv2:GetStages                                  |           |
 |                            | apigatewayv2:GetVpcLinks                                |           |
-| WAF-REGIONAL               | waf-regional:ListRules                                  | *         |
+| WAFREGIONAL                | waf-regional:ListRules                                  | *         |
 |                            | waf-regional:GetRule                                    |           |
 |                            | waf-regional:ListRuleGroups                             |           |
 |                            | waf-regional:GetRuleGroup                               |           |

--- a/main.tf
+++ b/main.tf
@@ -140,7 +140,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
       "waf-regional:GetRule",
       "waf-regional:ListRuleGroups",
       "waf-regional:GetRuleGroup",
-      "waf-regional:ListActivatedRuleInRuleGroup"
+      "waf-regional:ListActivatedRulesInRuleGroup"
     ]
     resources = ["*"]
   }

--- a/main.tf
+++ b/main.tf
@@ -140,8 +140,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
       "waf-regional:GetRule",
       "waf-regional:ListRuleGroups",
       "waf-regional:GetRuleGroup",
-      "waf-regional:ListActivatedRulesInRuleGroup"
-    ]
+    "waf-regional:ListActivatedRulesInRuleGroup"]
     resources = ["*"]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     resources = ["*"]
   }
   statement {
-    sid = "WAF-REGIONAL"
+    sid = "WAFREGIONAL"
     actions = ["waf-regional:ListRules",
       "waf-regional:GetRule",
       "waf-regional:ListRuleGroups",

--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,16 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     "apigatewayv2:GetVpcLinks"]
     resources = ["*"]
   }
+  statement {
+    sid = "WAF-REGIONAL"
+    actions = ["waf-regional:ListRules",
+      "waf-regional:GetRule",
+      "waf-regional:ListRuleGroups",
+      "waf-regional:GetRuleGroup",
+      "waf-regional:ListActivatedRuleInRuleGroup"
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary
AWS securityaudit policy doesn't have permission for these five waf APIs, we need these APIs in link ticket https://lacework.atlassian.net/browse/RAIN-90597

## How did you test this change?
Without this PR and the terraform apply, we see errors like
```
17:04:46.545 dev8.k8s.local aws-cfg-collector-shard-default 2023-11-10 01:04:46.545 +0000  ERROR    [pid: 23238] [ThreadPoolExecutor-1_0] pyservicecrawler.crawlers - envGuid="DEV8_B895FFBB65A0D5A2E543F62A2CB3CD9343293637C75D5C9BA80", startTime="1699585380000", assignmentSerial="00000475-of-00001853", msg="Exceptions were seen when fetching page with the message:", error_msg="An error occurred (AccessDeniedException) when calling the ListRules operation (reached max retries: 0): User: arn:aws:sts::631664038012:assumed-role/madroxqan-laceworkcwssarole/LACEWORK-CFG-external is not authorized to perform: waf-regional:ListRules on resource: arn:aws:waf-regional:eu-south-1:631664038012:rule/* because no identity-based policy allows the waf-regional:ListRules action", service="waf-regional", method_name="list_rules"
```
With this PR and terraform apply, the error is gone.


## Issue

<!--
  Include the link to a Jira/Github issue
-->
