### PR TITLE
feat(RAIN-90851): Add permission for two glue APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,4 @@ The audit policy is comprised of the following permissions:
 |                            | apigatewayv2:GetVpcLinks                                |           |
 | GLUE                       | glue:ListWorkflows                                      | *         |
 |                            | glue:BatchGetWorkflows                                  |           |
+|                            | glue:GetTags                                            |           |

--- a/README.md
+++ b/README.md
@@ -135,3 +135,5 @@ The audit policy is comprised of the following permissions:
 |                            | apigatewayv2:GetRouteResponses                          |           |
 |                            | apigatewayv2:GetStages                                  |           |
 |                            | apigatewayv2:GetVpcLinks                                |           |
+| GLUE                       | glue:ListWorkflows                                      | *         |
+|                            | glue:BatchGetWorkflows                                  |           |

--- a/main.tf
+++ b/main.tf
@@ -138,6 +138,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     sid = "GLUE"
     actions = ["glue:ListWorkflows",
       "glue:BatchGetWorkflows",
+      "glue:GetTags"
     ]
     resources = ["*"]
   }

--- a/main.tf
+++ b/main.tf
@@ -149,7 +149,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
-
+}
 
 resource "aws_iam_policy" "lacework_audit_policy" {
   count       = var.use_existing_iam_role_policy ? 0 : 1

--- a/main.tf
+++ b/main.tf
@@ -139,6 +139,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     actions = ["glue:ListWorkflows",
       "glue:BatchGetWorkflows",
       "glue:GetTags"]
+    resources = ["*"]
   }
 
   statement {

--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,13 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     "apigatewayv2:GetVpcLinks"]
     resources = ["*"]
   }
+  statement {
+    sid = "GLUE"
+    actions = ["glue:ListWorkflows",
+      "glue:BatchGetWorkflows",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary
Based on https://lacework.atlassian.net/browse/RAIN-71778, We need to add resource coverage for aws glue ListWorkflows and BatchGetWorkflows. 
This is one of the citi requirements

## How did you test this change?
Without this PR, crawl in dev8, we see the error like below.
```
An error occurred (AccessDeniedException) when calling the ListWorkflows operation (reached max retries: 0): User: arn:aws:sts::647104928493:assumed-role/lw-iam-472ef824/LACEWORK-CFG-external is not authorized to perform: glue:ListWorkflows because no identity-based policy allows the glue:ListWorkflows action", service="glue", method_name="list_workflows"
```
With this PR and also terraform apply, the error is gone

## Issue

<!--
  Include the link to a Jira/Github issue
-->
