### PR TITLE
feat(RAIN-91113): Add glacier permission for tags call

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,4 @@ The audit policy is comprised of the following permissions:
 |                            | apigatewayv2:GetRouteResponses                          |           |
 |                            | apigatewayv2:GetStages                                  |           |
 |                            | apigatewayv2:GetVpcLinks                                |           |
+| GLACIER                    | glacier:ListTagsForVault                                | *         |

--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,12 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     "apigatewayv2:GetVpcLinks"]
     resources = ["*"]
   }
+
+  statement {
+    sid = "GLACIER"
+    actions = ["glacier:ListTagsForVault"]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary
We are missing permission for tags call

## How did you test this change?
Trigger collection in dev8, and verify that the tag shows up. 
Verified with the follwoing query.
```

use schema AWS_CFG_INTERNAL;
select distinct resource_tags from aws_cfg_internal.config_details_t where service ='glacier' 
and PROPS:isSummaryRow = false 
```
## Issue
https://lacework.atlassian.net/browse/RAIN-91113
