### PR TITLE
feat(RAIN-91433): Add permission for get-api-keys in apigateway and apigatewayv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The audit policy is comprised of the following permissions:
 |                            | sso:DescribeInstanceAccessControlAttributeConfiguration |           |
 |                            | sso:GetInlinePolicyForPermissionSet                     |           |
 | GLACIER                    | glacier:ListTagsForVault                                | *         |
-| APIGATEWAY                 | apigateway:GET                                          | *         |
+| APIGATEWAY                 | apigateway:GET                                          | arn:aws:apigateway:*::/apikeys/*         |
 | WAFREGIONAL                | waf-regional:ListRules                                  | *         |
 |                            | waf-regional:GetRule                                    |           |
 |                            | waf-regional:ListRuleGroups                             |           |

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The audit policy is comprised of the following permissions:
 | SSO                        | sso:DescribeAccountAssignmentDeletionStatus             | *         |
 |                            | sso:DescribeInstanceAccessControlAttributeConfiguration |           |
 |                            | sso:GetInlinePolicyForPermissionSet                     |           |
+| GLACIER                    | glacier:ListTagsForVault                                | *         |
 | APIGATEWAY                 | apigateway:GET                                          | arn:aws:apigateway:*::/apikeys/*         |      |
 | WAFREGIONAL                | waf-regional:ListRules                                  | *         |
 |                            | waf-regional:GetRule                                    |           |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The audit policy is comprised of the following permissions:
 |                            | sso:DescribeInstanceAccessControlAttributeConfiguration |           |
 |                            | sso:GetInlinePolicyForPermissionSet                     |           |
 | GLACIER                    | glacier:ListTagsForVault                                | *         |
-| APIGATEWAY                 | apigateway:GET                                          |*         |      |
+| APIGATEWAY                 | apigateway:GET                                          | *         |
 | WAFREGIONAL                | waf-regional:ListRules                                  | *         |
 |                            | waf-regional:GetRule                                    |           |
 |                            | waf-regional:ListRuleGroups                             |           |

--- a/README.md
+++ b/README.md
@@ -101,41 +101,7 @@ The audit policy is comprised of the following permissions:
 | SSO                        | sso:DescribeAccountAssignmentDeletionStatus             | *         |
 |                            | sso:DescribeInstanceAccessControlAttributeConfiguration |           |
 |                            | sso:GetInlinePolicyForPermissionSet                     |           |
-| APIGATEWAY                 | apigateway:GetApiKeys                                   | *         |
-|                            | apigateway:GetAuthorizers                               |           |
-|                            | apigateway:GetBasePathMappings                          |           |
-|                            | apigateway:GetClientCertificates                        |           |
-|                            | apigateway:GetDeployments                               |           |
-|                            | apigateway:GetDocumentationParts                        |           |
-|                            | apigateway:GetDocumentationVersions                     |           |
-|                            | apigateway:GetDomainNames                               |           |
-|                            | apigateway:GetGatewayResponses                          |           |
-|                            | apigateway:GetModels                                    |           |
-|                            | apigateway:GetModelTemplate                             |           |
-|                            | apigateway:GetRequestValidators                         |           |
-|                            | apigateway:GetResources                                 |           |
-|                            | apigateway:GetRestApis                                  |           |
-|                            | apigateway:GetSdk                                       |           |
-|                            | apigateway:GetSdkTypes                                  |           |
-|                            | apigateway:GetStages                                    |           |
-|                            | apigateway:GetTags                                      |           |
-|                            | apigateway:GetUsagePlanKeys                             |           |
-|                            | apigateway:GetUsagePlans                                |           |
-|                            | apigateway:GetVpcLinks                                  |           |
-| APIGATEWAYV2               | apigatewayv2:GetApis                                    | *         |
-|                            | apigatewayv2:GetApiMappings                             |           |
-|                            | apigatewayv2:GetAuthorizers                             |           |
-|                            | apigatewayv2:GetDeployments                             |           |
-|                            | apigatewayv2:GetDomainNames                             |           |
-|                            | apigatewayv2:GetIntegrations                            |           |
-|                            | apigatewayv2:GetIntegrationResponses                    |           |
-|                            | apigatewayv2:GetModelTemplate                           |           |
-|                            | apigatewayv2:GetModels                                  |           |
-|                            | apigatewayv2:GetRoute                                   |           |
-|                            | apigatewayv2:GetRouteResponses                          |           |
-|                            | apigatewayv2:GetStages                                  |           |
-|                            | apigatewayv2:GetVpcLinks                                |           |
-| GLACIER                    | glacier:ListTagsForVault                                | *         |
+| APIGATEWAY                 | apigateway:GET                                          | arn:aws:apigateway:*::/apikeys/*         |      |
 | WAFREGIONAL                | waf-regional:ListRules                                  | *         |
 |                            | waf-regional:GetRule                                    |           |
 |                            | waf-regional:ListRuleGroups                             |           |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The audit policy is comprised of the following permissions:
 |                            | sso:DescribeInstanceAccessControlAttributeConfiguration |           |
 |                            | sso:GetInlinePolicyForPermissionSet                     |           |
 | GLACIER                    | glacier:ListTagsForVault                                | *         |
-| APIGATEWAY                 | apigateway:GET                                          | arn:aws:apigateway:*::/apikeys/*         |
+| APIGATEWAY                 | apigateway:GET                                          | arn:aws:apigateway:*::/apikeys, arn:aws:apigateway:*::/apikeys/*         |
 | WAFREGIONAL                | waf-regional:ListRules                                  | *         |
 |                            | waf-regional:GetRule                                    |           |
 |                            | waf-regional:ListRuleGroups                             |           |

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The audit policy is comprised of the following permissions:
 |                            | sso:DescribeInstanceAccessControlAttributeConfiguration |           |
 |                            | sso:GetInlinePolicyForPermissionSet                     |           |
 | GLACIER                    | glacier:ListTagsForVault                                | *         |
-| APIGATEWAY                 | apigateway:GET                                          | arn:aws:apigateway:*::/apikeys/*         |      |
+| APIGATEWAY                 | apigateway:GET                                          |*         |      |
 | WAFREGIONAL                | waf-regional:ListRules                                  | *         |
 |                            | waf-regional:GetRule                                    |           |
 |                            | waf-regional:ListRuleGroups                             |           |

--- a/main.tf
+++ b/main.tf
@@ -93,52 +93,10 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
 
   statement {
     sid = "APIGATEWAY"
-    actions = ["apigateway:GetApiKeys",
-      "apigateway:GetAuthorizers",
-      "apigateway:GetBasePathMappings",
-      "apigateway:GetClientCertificates",
-      "apigateway:GetDeployments",
-      "apigateway:GetDocumentationParts",
-      "apigateway:GetDocumentationVersions",
-      "apigateway:GetDomainNames",
-      "apigateway:GetGatewayResponses",
-      "apigateway:GetModels",
-      "apigateway:GetModelTemplate",
-      "apigateway:GetRequestValidators",
-      "apigateway:GetResources",
-      "apigateway:GetRestApis",
-      "apigateway:GetSdk",
-      "apigateway:GetSdkTypes",
-      "apigateway:GetStages",
-      "apigateway:GetTags",
-      "apigateway:GetUsagePlanKeys",
-      "apigateway:GetUsagePlans",
-    "apigateway:GetVpcLinks"]
-    resources = ["*"]
+    actions = ["apigateway:GET"]
+    resources = ["arn:aws:apigateway:*::/apikeys/*"]
   }
 
-  statement {
-    sid = "APIGATEWAYV2"
-    actions = ["apigatewayv2:GetApis",
-      "apigatewayv2:GetApiMappings",
-      "apigatewayv2:GetAuthorizers",
-      "apigatewayv2:GetDeployments",
-      "apigatewayv2:GetDomainNames",
-      "apigatewayv2:GetIntegrations",
-      "apigatewayv2:GetIntegrationResponses",
-      "apigatewayv2:GetModelTemplate",
-      "apigatewayv2:GetModels",
-      "apigatewayv2:GetRoute",
-      "apigatewayv2:GetRouteResponses",
-      "apigatewayv2:GetStages",
-    "apigatewayv2:GetVpcLinks"]
-    resources = ["*"]
-  }
-  statement {
-    sid = "GLACIER"
-    actions = ["glacier:ListTagsForVault"]
-    resources = ["*"]
-  }
   statement {
     sid = "WAFREGIONAL"
     actions = ["waf-regional:ListRules",

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   statement {
     sid = "APIGATEWAY"
     actions = ["apigateway:GET"]
-    resources = ["arn:aws:apigateway:*::/apikeys/*"]
+    resources = ["arn:aws:apigateway:*::/apikeys", "arn:aws:apigateway:*::/apikeys/*"]
   }
 
   statement {

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   statement {
     sid = "APIGATEWAY"
     actions = ["apigateway:GET"]
-    resources = ["arn:aws:apigateway:*::/apikeys/*"]
+    resources = ["*"]
   }
 
   statement {
@@ -102,7 +102,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     actions = ["glacier:ListTagsForVault"]
     resources = ["*"]
   }
-  
+
   statement {
     sid = "WAFREGIONAL"
     actions = ["waf-regional:ListRules",

--- a/main.tf
+++ b/main.tf
@@ -98,6 +98,12 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   }
 
   statement {
+    sid = "GLACIER"
+    actions = ["glacier:ListTagsForVault"]
+    resources = ["*"]
+  }
+  
+  statement {
     sid = "WAFREGIONAL"
     actions = ["waf-regional:ListRules",
       "waf-regional:GetRule",

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   statement {
     sid = "APIGATEWAY"
     actions = ["apigateway:GET"]
-    resources = ["*"]
+    resources = ["arn:aws:apigateway:*::/apikeys/*"]
   }
 
   statement {
@@ -102,7 +102,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     actions = ["glacier:ListTagsForVault"]
     resources = ["*"]
   }
-
+  
   statement {
     sid = "WAFREGIONAL"
     actions = ["waf-regional:ListRules",


### PR DESCRIPTION
## Summary
We do not have permission for get-api-keys in apigateway and apigatewayv2. 
In this PR, we are adding permissions for this API. 
First of all, apigateway and apigatewayv2 are controlled by the same iam actions.
In securityAudit, it actually has permissions for get APi for apigateway and apigatewayv2, but not for resource get-api-keys



## How did you test this change?

Verified that the error is access denied without the change. 
With this PR on the terraform change, access denied is gone.
Detail test is here https://docs.google.com/document/d/1eQowgxHJ6JXQdMx3oMI5usrI-TvqXq6iw3sm9AqsJp0/edit
## Issue
https://lacework.atlassian.net/browse/RAIN-91433
