### PR TITLE
feat(RAIN-91423): Add permissions for three sns APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,6 @@ The audit policy is comprised of the following permissions:
 |                            | glue:GetTags                                            |           |
 | CODEBUILD                  | codebuild:ListBuilds                                    | *         |
 |                            | codebuild:BatchGetBuilds                                |           |
+| SNS                        | sns:GetDataProtectionPolicy                             | *         |
+|                            | sns:ListPlatformApplications                            |           |
+|                            | sns:GetSubscriptionAttributes                           |           |

--- a/main.tf
+++ b/main.tf
@@ -158,6 +158,15 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid = "SNS"
+    actions = ["sns:GetDataProtectionPolicy",
+      "sns:ListPlatformApplications",
+      "sns:GetSubscriptionAttributes",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
Jira ticket is here 
https://lacework.atlassian.net/browse/RAIN-91423

## Summary
aws SecurityAudit policy doesn't have permission for these three SNS APIs. 

In this PR, I am adding permissions for these three APIs.
## How did you test this change?
The detail test is here https://docs.google.com/document/d/19HrNdVyQrCXARHzPYvOkq4Y3DZvJRmIC3GxKjDU7Np4/edit
1. Without the terraform change, we see all  Access Denied error. 

2. I changed terraform module for a test user. 
We no longer see access denied error for the user

## Issue
https://lacework.atlassian.net/browse/RAIN-91423