### PR TITLE
fix(RAIN-93896): Add permisssions for three ApiGateway resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -98,7 +98,14 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   statement {
     sid = "APIGATEWAY"
     actions = ["apigateway:GET"]
-    resources = ["arn:aws:apigateway:*::/apikeys", "arn:aws:apigateway:*::/apikeys/*"]
+    resources = ["arn:aws:apigateway:*::/apikeys",
+    "arn:aws:apigateway:*::/apikeys/*",
+    "arn:aws:apigateway:*::/domainnames/*/basepathmappings",
+    "arn:aws:apigateway:*::/domainnames/*/basepathmappings/*",
+    "arn:aws:apigateway:*::/usageplans",
+    "arn:aws:apigateway:*::/usageplans/*",
+    "arn:aws:apigateway:*::/restapis/*/stages/*/sdks",
+    "arn:aws:apigateway:*::/restapis/*/stages/*/sdks/*"]
   }
 
   statement {

--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     actions = ["apigateway:GET"]
     resources = ["arn:aws:apigateway:*::/apikeys",
     "arn:aws:apigateway:*::/apikeys/*",
+    "arn:aws:apigateway:*::/domainnames/*",
     "arn:aws:apigateway:*::/domainnames/*/basepathmappings",
     "arn:aws:apigateway:*::/domainnames/*/basepathmappings/*",
     "arn:aws:apigateway:*::/usageplans",

--- a/main.tf
+++ b/main.tf
@@ -104,8 +104,9 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     "arn:aws:apigateway:*::/domainnames/*/basepathmappings/*",
     "arn:aws:apigateway:*::/usageplans",
     "arn:aws:apigateway:*::/usageplans/*",
-    "arn:aws:apigateway:*::/restapis/*/stages/*/sdks",
-    "arn:aws:apigateway:*::/restapis/*/stages/*/sdks/*"]
+    "arn:aws:apigateway:*::/sdktypes",
+    "arn:aws:apigateway:*::/sdktypes/*"
+    ]
   }
 
   statement {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary
We are missing permissions for three apigateway resources: sdk-types, base-path-mapping, usage-plans

## How did you test this change?
1. Add resources in our dev8 environment.
2. Trigger the collection without the change. 
3. Check the log and I do see access denied errors https://onenr.io/01wZr1a64w6
4. Run terraform apply to our test account.
5. Trigger the collection again (The new collection started around 11am pdt on Oct 3)
Verify that no errors on access denied
https://onenr.io/0VjYrlO9vQ0
## Issue

<!--
  Include the link to a Jira/Github issue
-->
