### PR TITLE
feat(RAIN-71255): Add AWS permission for sesv2 APIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,24 @@ The audit policy is comprised of the following permissions:
 | SNS                        | sns:GetDataProtectionPolicy                             | *         |
 |                            | sns:ListPlatformApplications                            |           |
 |                            | sns:GetSubscriptionAttributes                           |           |
+| SES                        | ses:ListContactLists                                    | *         |
+|                            | ses:GetContactList                                      |           |
+|                            | ses:ListContacts                                        |           |
+|                            | ses:GetContact                                          |           |
+|                            | ses:ListCustomVerificationEmailTemplates                |           |
+|                            | ses:GetCustomVerificationEmailTemplate                  |           |
+|                            | ses:GetDedicatedIpPool                                  |           |
+|                            | ses:GetBlacklistReports                                 |           |
+|                            | ses:GetDedicatedIp                                      |           |
+|                            | ses:ListDeliverabilityTestReports                       |           |
+|                            | ses:GetDeliverabilityTestReport                         |           |
+|                            | ses:ListEmailIdentities                                 |           |
+|                            | ses:GetEmailIdentity                                    |           |
+|                            | ses:GetEmailIdentityPolicies                            |           |
+|                            | ses:ListEmailTemplates                                  |           |
+|                            | ses:GetEmailTemplate                                    |           |
+|                            | ses:ListImportJobs                                      |           |
+|                            | ses:GetImportJob                                        |           |
+|                            | ses:ListRecommendations                                 |           |
+|                            | ses:ListSuppressedDestinations                          |           |
+|                            | ses:GetSuppressedDestination                            |           |

--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     actions = ["glacier:ListTagsForVault"]
     resources = ["*"]
   }
-  
+
   statement {
     sid = "WAFREGIONAL"
     actions = ["waf-regional:ListRules",
@@ -153,6 +153,33 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   statement {
     sid = "STATES"
     actions = ["states:ListTagsForResource"]
+    resources = ["*"]
+  }
+
+    statement {
+    sid = "SES"
+    actions = ["ses:ListContactLists",
+      "ses:GetContactList",
+      "ses:ListContacts",
+      "ses:GetContact",
+      "ses:ListCustomVerificationEmailTemplates",
+      "ses:GetCustomVerificationEmailTemplate",
+      "ses:GetDedicatedIpPool",
+      "ses:GetBlacklistReports",
+      "ses:GetDedicatedIp",
+      "ses:ListDeliverabilityTestReports",
+      "ses:GetDeliverabilityTestReport",
+      "ses:ListEmailIdentities",
+      "ses:GetEmailIdentity",
+      "ses:GetEmailIdentityPolicies",
+      "ses:ListEmailTemplates",
+      "ses:GetEmailTemplate",
+      "ses:ListImportJobs",
+      "ses:GetImportJob",
+      "ses:ListRecommendations",
+      "ses:ListSuppressedDestinations",
+      "ses:GetSuppressedDestination",
+    ]
     resources = ["*"]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -165,8 +165,6 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
       "ses:ListCustomVerificationEmailTemplates",
       "ses:GetCustomVerificationEmailTemplate",
       "ses:GetDedicatedIpPool",
-      "ses:GetBlacklistReports",
-      "ses:GetDedicatedIp",
       "ses:ListDeliverabilityTestReports",
       "ses:GetDeliverabilityTestReport",
       "ses:ListEmailIdentities",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary

Adding permission for AWS role so that service coverage for SESv2 can successfully retrieve needed information.

## How did you test this change?
Tested in Tilt for enabled APIs that were failing due to access denied before applying this terraform.

## Issue

https://lacework.atlassian.net/browse/RAIN-71255
