### PR TITLE
feat(RAIN:Add permission for AWS service backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,27 @@ The audit policy is comprised of the following permissions:
 |                            | ses:ListRecommendations                                 |           |
 |                            | ses:ListSuppressedDestinations                          |           |
 |                            | ses:GetSuppressedDestination                            |           |
+| BACKUP                     | backup:ListBackupJobs                                   | *         |
+|                            | backup:DescribeBackupJob                                |           |
+|                            | backup:ListBackupPlanTemplates                          |           |
+|                            | backup:GetBackupPlanFromTemplate                        |           |
+|                            | backup:ListBackupPlans                                  |           |
+|                            | backup:GetBackupPlan                                    |           |
+|                            | backup:ListBackupPlanVersions                           |           |
+|                            | backup:ListBackupSelections                             |           |
+|                            | backup:GetBackupSelection                               |           |
+|                            | backup:DescribeBackupVault                              |           |
+|                            | backup:ListRecoveryPointsByBackupVault                  |           |
+|                            | backup:DescribeRecoveryPoint                            |           |
+|                            | backup:GetRecoveryPointRestoreMetadata                  |           |
+|                            | backup:ListCopyJobs                                     |           |
+|                            | backup:ListFrameworks                                   |           |
+|                            | backup:DescribeFramework                                |           |
+|                            | backup:ListLegalHolds                                   |           |
+|                            | backup:GetLegalHold                                     |           |
+|                            | backup:ListRecoveryPointsByLegalHold                    |           |
+|                            | backup:ListProtectedResources                           |           |
+|                            | backup:DescribeProtectedResource                        |           |
+|                            | backup:ListRecoveryPointsByResource                     |           |
+|                            | backup:ListReportPlans                                  |           |
+|                            | backup:ListRestoreJobs                                  |           |

--- a/main.tf
+++ b/main.tf
@@ -156,7 +156,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     resources = ["*"]
   }
 
-    statement {
+  statement {
     sid = "SES"
     actions = ["ses:ListContactLists",
       "ses:GetContactList",
@@ -177,6 +177,36 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
       "ses:ListRecommendations",
       "ses:ListSuppressedDestinations",
       "ses:GetSuppressedDestination",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "BACKUP"
+    actions = ["backup:ListBackupJobs",
+      "backup:DescribeBackupJob",
+      "backup:ListBackupPlanTemplates",
+      "backup:GetBackupPlanFromTemplate",
+      "backup:ListBackupPlans",
+      "backup:GetBackupPlan",
+      "backup:ListBackupPlanVersions",
+      "backup:ListBackupSelections",
+      "backup:GetBackupSelection",
+      "backup:DescribeBackupVault",
+      "backup:ListRecoveryPointsByBackupVault",
+      "backup:DescribeRecoveryPoint",
+      "backup:GetRecoveryPointRestoreMetadata",
+      "backup:ListCopyJobs",
+      "backup:ListFrameworks",
+      "backup:DescribeFramework",
+      "backup:ListLegalHolds",
+      "backup:GetLegalHold",
+      "backup:ListRecoveryPointsByLegalHold",
+      "backup:ListProtectedResources",
+      "backup:DescribeProtectedResource",
+      "backup:ListRecoveryPointsByResource",
+      "backup:ListReportPlans",
+      "backup:ListRestoreJobs",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary
RM is adding AWS service coverage for BACKUP, we are missing permissions for couple of the APIS


## How did you test this change?
Testing in tilt after enabling the APIs that were disabled.

## Issue

[RAIN-94028](https://lacework.atlassian.net/browse/RAIN-94028)
