### PR TITLE
fix: add glue:GetWorkflows to GLUE statement

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,6 +128,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   statement {
     sid = "GLUE"
     actions = ["glue:ListWorkflows",
+      "glue:GetWorkflows",
       "glue:BatchGetWorkflows",
       "glue:GetTags"]
     resources = ["*"]


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
-->

Add `glue:GetWorkflows` permissions to GLUE statement in order to resolve AWS Health alert and to prevent issues on the 16th December when AWS implements the fix mentioned below:

```
Currently, Glue BatchGet* APIs run successfully despite a Deny condition on one or more of the underlying Get operations. On December 16, 2024, we will deploy a fix for this to ensure BatchGet* APIs will fail with an AccessDeniedException if there is a Deny condition on one of the corresponding Get* operations. Your account has policies which include these contradicting statements. Please refer to the 'Affected resources' tab of your AWSHealth Dashboard to see your impacted IAM resources.

You must update your policies to deny or allow AWS Glue Batch* APIs and their corresponding Get* API operations by this date. If you do not take action, the Batch API will not retrieve the resources of the Batch API call being made.
```

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

Manually updated the policy in an affected AWS account to confirm the issue is resolved. 

## Issue

<!--
  Include the link to a Jira/Github issue
-->

https://github.com/lacework/terraform-aws-config/issues/109