### PR TITLE
feat(LINK-3437): Add permission for Glue:Getworkflow

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,6 +129,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     sid = "GLUE"
     actions = ["glue:ListWorkflows",
       "glue:BatchGetWorkflows",
+      "glue:GetWorkflows",
       "glue:GetTags"]
     resources = ["*"]
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary
The discussion is here https://lacework.slack.com/archives/CR6RN9PSL/p1732207375373039
AWS announces the following change.
Essentially, it says that BatchGetworkflows will get access denied if the rule says Getworkflow is denied. 
To be safe, we explicitly set allow for operation glue:Getworkflow.
```
We identified an issue with AWS Glue BatchGet APIs that requires your action. Currently, Glue BatchGet* APIs run successfully despite a Deny condition on one or more of the underlying Get operations. On December 16, 2024, we will deploy a fix for this to ensure BatchGet* APIs will fail with an AccessDeniedException if there is a Deny condition on one of the corresponding Get* operations. Your account has policies which include these contradicting statements. Please refer to the 'Affected resources' tab of your AWS Health Dashboard to see your impacted IAM resources.

You must update your policies to deny or allow AWS Glue Batch* APIs and their corresponding Get* API operations by this date. If you do not take action, the Batch API will not retrieve the resources of the Batch API call being made. Please refer to our "Actions, resources, and condition keys for AWS Glue" user guide for additional information [1].

The following is a list of the affected Glue BatchGet* APIs operations:

BatchGetDevEndpoints
BatchGetJobs
BatchGetBlueprints
BatchGetTriggers
BatchGetWorkflows

The following is a list of the affected Get* API operations:

GetDevEndpoints
GetJobs
GetBlueprints
GetTriggers
GetWorkflows

If you have any questions or concerns, please contact AWS Support [2].

[1] https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsglue.html
[2] https://aws.amazon.com/support

```
## How did you test this change?
This is to prevent the incoming changes for aws. 

## Issue
https://lacework.atlassian.net/browse/LINK-3437
