### PR TITLE
feat(RAIN-94027): add terraform permissions for AWS service compute-optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,13 @@ The audit policy is comprised of the following permissions:
 |                            | ses:ListRecommendations                                 |           |
 |                            | ses:ListSuppressedDestinations                          |           |
 |                            | ses:GetSuppressedDestination                            |           |
+| COMPUTE-OPTIMIZER          | compute-optimizer:DescribeRecommendationExportJobs      | *         |
+|                            | compute-optimizer:GetAutoScalingGroupRecommendations    |           |
+|                            | compute-optimizer:GetEffectiveRecommendationPreferences |           |
+|                            | compute-optimizer:GetEBSVolumeRecommendations           |           |
+|                            | compute-optimizer:GetEC2InstanceRecommendations         |           |
+|                            | compute-optimizer:GetEnrollmentStatus                   |           |
+|                            | compute-optimizer:GetEnrollmentStatusesForOrganization  |           |
+|                            | compute-optimizer:GetLambdaFunctionRecommendations      |           |
+|                            | compute-optimizer:GetRecommendationPreferences          |           |
+|                            | compute-optimizer:GetRecommendationSummaries            |           |

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The audit policy is comprised of the following permissions:
 |                            | ses:ListRecommendations                                 |           |
 |                            | ses:ListSuppressedDestinations                          |           |
 |                            | ses:GetSuppressedDestination                            |           |
-| COMPUTE-OPTIMIZER          | compute-optimizer:DescribeRecommendationExportJobs      | *         |
+| COMPUTEOPTIMIZER          | compute-optimizer:DescribeRecommendationExportJobs      | *         |
 |                            | compute-optimizer:GetAutoScalingGroupRecommendations    |           |
 |                            | compute-optimizer:GetEffectiveRecommendationPreferences |           |
 |                            | compute-optimizer:GetEBSVolumeRecommendations           |           |

--- a/main.tf
+++ b/main.tf
@@ -182,7 +182,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   }
 
   statement {
-    sid       = "COMPUTE-OPTIMIZER"
+    sid       = "COMPUTEOPTIMIZER"
     actions   = [
       "compute-optimizer:DescribeRecommendationExportJobs",
       "compute-optimizer:GetAutoScalingGroupRecommendations",

--- a/main.tf
+++ b/main.tf
@@ -180,6 +180,23 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid       = "COMPUTE-OPTIMIZER"
+    actions   = [
+      "compute-optimizer:DescribeRecommendationExportJobs",
+      "compute-optimizer:GetAutoScalingGroupRecommendations",
+      "compute-optimizer:GetEffectiveRecommendationPreferences",
+      "compute-optimizer:GetEBSVolumeRecommendations",
+      "compute-optimizer:GetEC2InstanceRecommendations",
+      "compute-optimizer:GetEnrollmentStatus",
+      "compute-optimizer:GetEnrollmentStatusesForOrganization",
+      "compute-optimizer:GetLambdaFunctionRecommendations",
+      "compute-optimizer:GetRecommendationPreferences",
+      "compute-optimizer:GetRecommendationSummaries"
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
## Summary

Add terraform permissions for AWS service compute-optimizer

## How did you test this change?

Tested in tilt. Permissions are added only for `dev8-rm-test` account (249446771485). By running the queries below, we can see `AccessDeniedException` in other accounts except account_id of 249446771485. 

```
-- Collection completed for envGuid: DEV8_B895FFBB65A0D5A2E543F62A2CB3CD9343293637C75D5C9BA80 
-- with startTime: 2024-12-04T08:10:00 and endTime: 2024-12-04T08:20:00

use database DEV8_CDB_DEV8_B895FFBB65A0D5A2E543F62A2CB3CD9343293637C75D5C9BA80;

select request_guid, start_time, end_time from aws_cfg_internal.config_summary_t
where start_time = '2024-12-04T08:10:00-00:00' and end_time = '2024-12-04T08:20:00-00:00';

SELECT DISTINCT account_id, service, api_key, status
FROM aws_cfg_internal.config_preview_details_t
WHERE REQUEST_GUID = 'c5578dc6-cefd-41fe-a081-209c0619458a';
```

## Issue

https://lacework.atlassian.net/browse/RAIN-94027
