### PR TITLE
Feat(RAIN-94095): add permission for AWS Cognito-idp service

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,7 @@ The audit policy is comprised of the following permissions:
 |                            | backup:ListRecoveryPointsByResource                     |           |
 |                            | backup:ListReportPlans                                  |           |
 |                            | backup:ListRestoreJobs                                  |           |
+| COGNITO-IDP                | cognito-idp:GetSigningCertificate                       |           |
+|                            | cognito-idp:GetCSVHeader                                |           |
+|                            | cognito-idp:GetUserPoolMfaConfig                        |           |
+|                            | cognito-idp:GetUICustomization                          |           |

--- a/main.tf
+++ b/main.tf
@@ -210,6 +210,16 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid = "COGNITOIDP"
+    actions = ["cognito-idp:GetSigningCertificate",
+      "cognito-idp:GetCSVHeader",
+      "cognito-idp:GetUserPoolMfaConfig",
+      "cognito-idp:GetUICustomization",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary

Missing couple API permissions of new added AWS service Cognito-idp

## How did you test this change?

Tested in Dev8

- Before
![image](https://github.com/user-attachments/assets/a4d5e9b5-743e-4e7f-bc61-2e92bf44b991)

- After
![image](https://github.com/user-attachments/assets/4fd66d53-de38-4fa9-b921-8de43a0126a2)

## Issue

[RAIN-94095](https://lacework.atlassian.net/browse/RAIN-94095)


[RAIN-94095]: https://lacework.atlassian.net/browse/RAIN-94095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ