### PR TITLE
fix: Fix the GetWorkflow typo

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     sid = "GLUE"
     actions = ["glue:ListWorkflows",
       "glue:BatchGetWorkflows",
-      "glue:GetWorkflows",
+      "glue:GetWorkflow",
       "glue:GetTags"]
     resources = ["*"]
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary

`[Glue:GetWorkflow](https://docs.aws.amazon.com/glue/latest/dg/aws-glue-api-workflow.html#aws-glue-api-workflow-GetWorkflow)` instead of GetWorkflows

## How did you test this change?

<!--
  How exactly did you verify that your PR solves the issue you wanted to solve?
  Include any other relevant information such as how to use the new functionality, screenshots, etc.
-->

## Issue

[LINK-3464](https://lacework.atlassian.net/browse/LINK-3464)


[LINK-3464]: https://lacework.atlassian.net/browse/LINK-3464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ