### PR TITLE
feat(RAIN-94144): Add permission for service AMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,3 +182,11 @@ The audit policy is comprised of the following permissions:
 |                            | kinesisanalytics:ListApplicationVersions                |           |
 |                            | kinesisanalytics:DescribeApplicationVersion             |           |
 |                            | kinesisanalytics:DescribeApplication                    |           |
+| AMP                        | aps:ListScrapers                                        | *         |
+|                            | aps:DescribeScraper                                     |           |
+|                            | aps:ListWorkspaces                                      |           |
+|                            | aps:DescribeAlertManagerDefinition                      |           |
+|                            | aps:DescribeLoggingConfiguration                        |           |
+|                            | aps:DescribeWorkspace                                   |           |
+|                            | aps:ListRuleGroupsNamespaces                            |           |
+|                            | aps:DescribeRuleGroupsNamespace                         |           |

--- a/main.tf
+++ b/main.tf
@@ -248,6 +248,20 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid = "AMP"
+    actions = ["aps:ListScrapers",
+      "aps:DescribeScraper",
+      "aps:ListWorkspaces",
+      "aps:DescribeAlertManagerDefinition",
+      "aps:DescribeLoggingConfiguration",
+      "aps:DescribeWorkspace",
+      "aps:ListRuleGroupsNamespaces",
+      "aps:DescribeRuleGroupsNamespace",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
## Summary

Adding permissions for APIs under service AMP(APS) Managed Service for Prometheus

## How did you test this change?
Initially no permission for all APIs under APS, tested this in tilt and confirms that.
Added the permission through terraform and can confirm that all implicit access permission denied errors are gone.

[AMP test logs without permission](https://drive.google.com/file/d/1snEK-TGP_RnW1QBk3t9Jt6NfyRKgm7K5/view?usp=drive_link)
[AMP test logs with permission](https://drive.google.com/file/d/103qCQRAhTOMLRZqEnmabxI2vtZmchDBx/view?usp=drive_link)

## Issue
https://lacework.atlassian.net/browse/RAIN-94144