### PR TITLE
Feat(RAIN-94160): Add permissions for AWS appstream service

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,5 @@ The audit policy is comprised of the following permissions:
 |                            | aps:DescribeWorkspace                                   |           |
 |                            | aps:ListRuleGroupsNamespaces                            |           |
 |                            | aps:DescribeRuleGroupsNamespace                         |           |
+| APPSTREAM                  | appstream:Describe*                                     |           |
+|                            | appstream:List*                                         |           |

--- a/main.tf
+++ b/main.tf
@@ -262,6 +262,14 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid = "APPSTREAM"
+    actions = ["appstream:Describe*",
+      "appstream:List*",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
## Summary
Add missing permissions for AWS appstream service

## How did you test this change?
Tested in Dev8

- Before
![image](https://github.com/user-attachments/assets/5c8a548f-cd48-49c3-9e9b-a17ebba82a24)

- After
![image](https://github.com/user-attachments/assets/f0c90dcb-351c-4cf1-ad4a-e28b2f312eb7)

## Issue
[RAIN-94160](https://lacework.atlassian.net/browse/RAIN-94160)


[RAIN-94160]: https://lacework.atlassian.net/browse/RAIN-94160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ