### PR TITLE
feat(RAIN-94177,RAIN-94159): Add permission for both codeartifact and fis

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,23 @@ The audit policy is comprised of the following permissions:
 |                            | aps:DescribeRuleGroupsNamespace                         |           |
 | APPSTREAM                  | appstream:Describe*                                     |           |
 |                            | appstream:List*                                         |           |
+| CODEARTIFACT               | codeartifact:ListDomains                                | *         |
+|                            | codeartifact:DescribeDomain                             |           |
+|                            | codeartifact:DescribeRepository                         |           |
+|                            | codeartifact:ListPackages                               |           |
+|                            | codeartifact:GetRepositoryEndpoint                      |           |
+|                            | codeartifact:DescribePackage                            |           |
+|                            | codeartifact:ListPackageVersions                        |           |
+|                            | codeartifact:DescribePackageVersion                     |           |
+|                            | codeartifact:GetPackageVersionReadme                    |           |
+|                            | codeartifact:ListPackageVersionDependencies             |           |
+|                            | codeartifact:ListPackageVersionAssets                   |           |
+|                            | codeartifact:GetPackageVersionAsset                     |           |
+| FIS                        | fis:ListActions                                         | *         |
+|                            | fis:GetAction                                           |           |
+|                            | fis:ListExperimentTemplates                             |           |
+|                            | fis:GetExperimentTemplate                               |           |
+|                            | fis:ListTargetAccountConfigurations                     |           |
+|                            | fis:ListExperiments                                     |           |
+|                            | fis:GetExperiment                                       |           |
+|                            | fis:ListExperimentResolvedTargets                       |           |

--- a/main.tf
+++ b/main.tf
@@ -270,6 +270,38 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid = "CODEARTIFACT"
+    actions = ["codeartifact:ListDomains",
+      "codeartifact:DescribeDomain",
+      "codeartifact:DescribeRepository",
+      "codeartifact:ListPackages",
+      "codeartifact:GetRepositoryEndpoint",
+      "codeartifact:DescribePackage",
+      "codeartifact:ListPackageVersions",
+      "codeartifact:DescribePackageVersion",
+      "codeartifact:GetPackageVersionReadme",
+      "codeartifact:ListPackageVersionDependencies",
+      "codeartifact:ListPackageVersionAssets",
+      "codeartifact:GetPackageVersionAsset",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "FIS"
+    actions = ["fis:ListActions",
+        "fis:GetAction",
+        "fis:ListExperimentTemplates",
+        "fis:GetExperimentTemplate",
+        "fis:ListTargetAccountConfigurations",
+        "fis:ListExperiments",
+        "fis:GetExperiment",
+        "fis:ListExperimentResolvedTargets",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
RM needs to add new service coverages for codeartifact and FIS. But currently we dont have those permissions for the APIs under those, thus we need to add these permissions on top through terraform

## How did you test this change?

Tested in tilt before and after the permissions are added

## Issue

https://lacework.atlassian.net/browse/RAIN-94159
https://lacework.atlassian.net/browse/RAIN-94177
