### PR TITLE
Feat(RAIN-94178): Add AWS Personalize service permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,3 +192,6 @@ The audit policy is comprised of the following permissions:
 |                            | aps:DescribeRuleGroupsNamespace                         |           |
 | APPSTREAM                  | appstream:Describe*                                     |           |
 |                            | appstream:List*                                         |           |
+| PERSONALIZE                | personalize:Describe*                                   |           |
+|                            | personalize:List*                                       |           |
+|                            | personalize:GetSolutionMetrics                          |           |

--- a/main.tf
+++ b/main.tf
@@ -270,6 +270,15 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
+
+  statement {
+    sid = "PERSONALIZE"
+    actions = ["personalize:Describe*",
+      "personalize:List*",
+      "personalize:GetSolutionMetrics",
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {


### PR DESCRIPTION
## Summary
Add permissions for AWS Personalize service

## How did you test this change?
Tested in tilt
- Before
![image](https://github.com/user-attachments/assets/a21fe50c-a262-42e6-bf86-abba18d83b10)
- After
![image](https://github.com/user-attachments/assets/545a8fcf-e3ba-4ae7-bb6e-a12167be8b3b)

## Issue
[RAIN-94178](https://lacework.atlassian.net/browse/RAIN-94178)


[RAIN-94178]: https://lacework.atlassian.net/browse/RAIN-94178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ