### PR TITLE
chore(): Remove permission that already exist in v48 security audit policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -50,13 +50,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
 
   statement {
     sid = "EFS"
-    actions = ["elasticfilesystem:DescribeFileSystemPolicy",
-      "elasticfilesystem:DescribeLifecycleConfiguration",
-      "elasticfilesystem:DescribeAccessPoints",
-      "elasticfilesystem:DescribeAccountPreferences",
-      "elasticfilesystem:DescribeBackupPolicy",
-      "elasticfilesystem:ListTagsForResource",
-    "elasticfilesystem:DescribeReplicationConfigurations"]
+    actions = ["elasticfilesystem:ListTagsForResource"]
     resources = ["*"]
   }
 
@@ -78,12 +72,8 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   statement {
     sid = "IDENTITYSTORE"
     actions = ["identitystore:DescribeGroup",
-      "identitystore:DescribeGroupMembership",
-      "identitystore:DescribeUser",
-      "identitystore:ListGroupMemberships",
-      "identitystore:ListGroupMembershipsForMember",
-      "identitystore:ListGroups",
-    "identitystore:ListUsers"]
+    "identitystore:DescribeGroupMembership",
+    "identitystore:DescribeUser"]
     resources = ["*"]
   }
 
@@ -129,8 +119,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     sid = "GLUE"
     actions = ["glue:ListWorkflows",
       "glue:BatchGetWorkflows",
-      "glue:GetWorkflow",
-      "glue:GetTags"]
+      "glue:GetWorkflow"]
     resources = ["*"]
   }
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary
Removing permissions that already exist

## How did you test this change?

Tested in DEV account

