### PR TITLE
feat(RAIN-94239): Rm modify terraform to add a policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 | Name | Type |
 |------|------|
 | [aws_iam_policy.lacework_audit_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.lacework_audit_policy_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.lacework_audit_policy_2025_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role_policy_attachment.lacework_audit_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lacework_audit_policy_attachment_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.security_audit_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -46,7 +46,7 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [time_sleep.wait_time](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_iam_policy_document.lacework_audit_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.lacework_audit_policy_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lacework_audit_policy_2025_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [lacework_metric_module.lwmetrics](https://registry.terraform.io/providers/lacework/lacework/latest/docs/data-sources/metric_module) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -38,12 +38,15 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 | Name | Type |
 |------|------|
 | [aws_iam_policy.lacework_audit_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.lacework_audit_policy_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role_policy_attachment.lacework_audit_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lacework_audit_policy_attachment_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.security_audit_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [lacework_integration_aws_cfg.default](https://registry.terraform.io/providers/lacework/lacework/latest/docs/resources/integration_aws_cfg) | resource |
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [time_sleep.wait_time](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_iam_policy_document.lacework_audit_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lacework_audit_policy_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [lacework_metric_module.lwmetrics](https://registry.terraform.io/providers/lacework/lacework/latest/docs/data-sources/metric_module) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -195,3 +195,23 @@ The audit policy is comprised of the following permissions:
 | PERSONALIZE                | personalize:Describe*                                   |           |
 |                            | personalize:List*                                       |           |
 |                            | personalize:GetSolutionMetrics                          |           |
+| CODEARTIFACT               | codeartifact:ListDomains                                | *         |
+|                            | codeartifact:DescribeDomain                             |           |
+|                            | codeartifact:DescribeRepository                         |           |
+|                            | codeartifact:ListPackages                               |           |
+|                            | codeartifact:GetRepositoryEndpoint                      |           |
+|                            | codeartifact:DescribePackage                            |           |
+|                            | codeartifact:ListPackageVersions                        |           |
+|                            | codeartifact:DescribePackageVersion                     |           |
+|                            | codeartifact:GetPackageVersionReadme                    |           |
+|                            | codeartifact:ListPackageVersionDependencies             |           |
+|                            | codeartifact:ListPackageVersionAssets                   |           |
+|                            | codeartifact:GetPackageVersionAsset                     |           |
+| FIS                        | fis:ListActions                                         | *         |
+|                            | fis:GetAction                                           |           |
+|                            | fis:ListExperimentTemplates                             |           |
+|                            | fis:GetExperimentTemplate                               |           |
+|                            | fis:ListTargetAccountConfigurations                     |           |
+|                            | fis:ListExperiments                                     |           |
+|                            | fis:GetExperiment                                       |           |
+|                            | fis:ListExperimentResolvedTargets                       |           |

--- a/README.md
+++ b/README.md
@@ -178,14 +178,18 @@ The audit policy is comprised of the following permissions:
 |                            | compute-optimizer:GetEBSVolumeRecommendations           |           |
 |                            | compute-optimizer:GetEC2InstanceRecommendations         |           |
 |                            | compute-optimizer:GetEnrollmentStatus                   |           |
-|                            | compute-optimizer:GetEnrollmentStatusesForOrganization  |           |
 |                            | compute-optimizer:GetLambdaFunctionRecommendations      |           |
 |                            | compute-optimizer:GetRecommendationPreferences          |           |
 |                            | compute-optimizer:GetRecommendationSummaries            |           |
+|                            | compute-optimizer:GetEcsServiceRecommendations          |           |
+|                            | compute-optimizer:GetLicenseRecommendations             |           |
 | KINESISANALYTICS           | kinesisanalytics:ListApplicationSnapshots               |           |
 |                            | kinesisanalytics:ListApplicationVersions                |           |
 |                            | kinesisanalytics:DescribeApplicationVersion             |           |
 |                            | kinesisanalytics:DescribeApplication                    |           |
+| KINESISVIDEO               | kinesisvideo:GetSignalingChannelEndpoint                | *         |
+|                            | kinesisvideo:GetDataEndpoint                            |           |
+|                            | kinesisvideo:DescribeImageGenerationConfiguration       |           |
 | AMP                        | aps:ListScrapers                                        | *         |
 |                            | aps:DescribeScraper                                     |           |
 |                            | aps:ListWorkspaces                                      |           |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 ## Lacework Audit Policy
 
 The Lacework audit policy extends the SecurityAudit policy to facilitate the reading of additional configuration resources.
+As of 1/22/2025, we have exceeded the limit of 6144 characters for a single policy, thus every service starting with codeartifact are in a new policy.
 The audit policy is comprised of the following permissions:
 
 | sid                        | actions                                                 | resources |

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 ## Lacework Audit Policy
 
 The Lacework audit policy extends the SecurityAudit policy to facilitate the reading of additional configuration resources.
-As of 1/22/2025, we have exceeded the limit of 6144 characters for a single policy, thus every service starting with codeartifact are in a new policy.
+As of 1/22/2025, we have exceeded the limit of 6144 characters for a single policy, thus every service starting with KINESISVIDEO are in a new policy: lwaudit-policy-${random_id.uniq.hex}-2025-1
 The audit policy is comprised of the following permissions:
 
 | sid                        | actions                                                 | resources |

--- a/main.tf
+++ b/main.tf
@@ -223,10 +223,11 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
       "compute-optimizer:GetEBSVolumeRecommendations",
       "compute-optimizer:GetEC2InstanceRecommendations",
       "compute-optimizer:GetEnrollmentStatus",
-      "compute-optimizer:GetEnrollmentStatusesForOrganization",
       "compute-optimizer:GetLambdaFunctionRecommendations",
       "compute-optimizer:GetRecommendationPreferences",
-      "compute-optimizer:GetRecommendationSummaries"
+      "compute-optimizer:GetRecommendationSummaries",
+      "compute-optimizer:GetEcsServiceRecommendations",
+      "compute-optimizer:GetLicenseRecommendations",
     ]
     resources = ["*"]
   }
@@ -237,6 +238,15 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
       "kinesisanalytics:ListApplicationVersions",
       "kinesisanalytics:DescribeApplicationVersion",
       "kinesisanalytics:DescribeApplication",
+    ]
+    resources = ["*"]
+  }
+
+    statement {
+    sid = "KINESISVIDEO"
+    actions = ["kinesisvideo:GetSignalingChannelEndpoint",
+      "kinesisvideo:GetDataEndpoint",
+      "kinesisvideo:DescribeImageGenerationConfiguration",
     ]
     resources = ["*"]
   }

--- a/main.tf
+++ b/main.tf
@@ -241,47 +241,6 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
-
-  statement {
-    sid = "KINESISVIDEO"
-    actions = ["kinesisvideo:GetSignalingChannelEndpoint",
-      "kinesisvideo:GetDataEndpoint",
-      "kinesisvideo:DescribeImageGenerationConfiguration",
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    sid = "AMP"
-    actions = ["aps:ListScrapers",
-      "aps:DescribeScraper",
-      "aps:ListWorkspaces",
-      "aps:DescribeAlertManagerDefinition",
-      "aps:DescribeLoggingConfiguration",
-      "aps:DescribeWorkspace",
-      "aps:ListRuleGroupsNamespaces",
-      "aps:DescribeRuleGroupsNamespace",
-      "aps:ListTagsForResource",
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    sid = "APPSTREAM"
-    actions = ["appstream:Describe*",
-      "appstream:List*",
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    sid = "PERSONALIZE"
-    actions = ["personalize:Describe*",
-      "personalize:List*",
-      "personalize:GetSolutionMetrics",
-    ]
-    resources = ["*"]
-  }
 }
 
 # AWS iam allows only 6144 characters in a single policy
@@ -322,6 +281,47 @@ data "aws_iam_policy_document" "lacework_audit_policy_2025_1" {
         "fis:GetExperiment",
         "fis:ListExperimentResolvedTargets",
         "fis:ListTagsForResource",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "KINESISVIDEO"
+    actions = ["kinesisvideo:GetSignalingChannelEndpoint",
+      "kinesisvideo:GetDataEndpoint",
+      "kinesisvideo:DescribeImageGenerationConfiguration",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "AMP"
+    actions = ["aps:ListScrapers",
+      "aps:DescribeScraper",
+      "aps:ListWorkspaces",
+      "aps:DescribeAlertManagerDefinition",
+      "aps:DescribeLoggingConfiguration",
+      "aps:DescribeWorkspace",
+      "aps:ListRuleGroupsNamespaces",
+      "aps:DescribeRuleGroupsNamespace",
+      "aps:ListTagsForResource",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "APPSTREAM"
+    actions = ["appstream:Describe*",
+      "appstream:List*",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "PERSONALIZE"
+    actions = ["personalize:Describe*",
+      "personalize:List*",
+      "personalize:GetSolutionMetrics",
     ]
     resources = ["*"]
   }

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
   lacework_audit_policy_name = (
     length(var.lacework_audit_policy_name) > 0 ? var.lacework_audit_policy_name : "lwaudit-policy-${random_id.uniq.hex}"
   )
-  lacework_audit_policy_name_b = "${lacework_audit_policy_name}-b"
+  lacework_audit_policy_name_b = "${local.lacework_audit_policy_name}-b"
   version_file   = "${abspath(path.module)}/VERSION"
   module_name    = "terraform-aws-config"
   module_version = fileexists(local.version_file) ? file(local.version_file) : ""

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ locals {
   lacework_audit_policy_name = (
     length(var.lacework_audit_policy_name) > 0 ? var.lacework_audit_policy_name : "lwaudit-policy-${random_id.uniq.hex}"
   )
-  lacework_audit_policy_name_b = "${local.lacework_audit_policy_name}-b"
+  lacework_audit_policy_name_2025_1 = "${local.lacework_audit_policy_name}-2025-1"
   version_file   = "${abspath(path.module)}/VERSION"
   module_name    = "terraform-aws-config"
   module_version = fileexists(local.version_file) ? file(local.version_file) : ""
@@ -140,8 +140,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
-
-  statement {
+`  statement {
     sid = "STATES"
     actions = ["states:ListTagsForResource"]
     resources = ["*"]
@@ -286,8 +285,9 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
 
 # AWS iam allows only 6144 characters in a single policy
 # We've come to a point where there are too many actions in a single policy which is causing the policy to exceed the limit
-# So we needed a new policy to accommodate the overflow of actions, thus we added this new policy "lacework_audit_policy_b"
-data "aws_iam_policy_document" "lacework_audit_policy_b" {
+# So we needed a new policy to accommodate the overflow of actions, thus we added this new policy "lacework_audit_policy_2025_1"
+# Which representing the first new policy in 2025
+data "aws_iam_policy_document" "lacework_audit_policy_2025_1" {
   count   = var.use_existing_iam_role_policy ? 0 : 1
   version = "2012-10-17"
 
@@ -334,11 +334,11 @@ resource "aws_iam_policy" "lacework_audit_policy" {
   tags        = var.tags
 }
 
-resource "aws_iam_policy" "lacework_audit_policy_b" {
+resource "aws_iam_policy" "lacework_audit_policy_2025_1" {
   count       = var.use_existing_iam_role_policy ? 0 : 1
-  name        = local.lacework_audit_policy_name_b
+  name        = local.lacework_audit_policy_name_2025_1
   description = "An audit policy to allow Lacework to read configs (extends SecurityAudit), this is the second policy"
-  policy      = data.aws_iam_policy_document.lacework_audit_policy_b[0].json
+  policy      = data.aws_iam_policy_document.lacework_audit_policy_2025_1[0].json
   tags        = var.tags
 }
 
@@ -352,7 +352,7 @@ resource "aws_iam_role_policy_attachment" "lacework_audit_policy_attachment" {
 resource "aws_iam_role_policy_attachment" "lacework_audit_policy_attachment_b" {
   count      = var.use_existing_iam_role_policy ? 0 : 1
   role       = local.iam_role_name
-  policy_arn = aws_iam_policy.lacework_audit_policy_b[0].arn
+  policy_arn = aws_iam_policy.lacework_audit_policy_2025_1[0].arn
   depends_on = [module.lacework_cfg_iam_role]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -322,7 +322,6 @@ resource "aws_iam_policy" "lacework_audit_policy" {
   tags        = var.tags
 }
 
-
 resource "aws_iam_policy" "lacework_audit_policy_b" {
   count       = var.use_existing_iam_role_policy ? 0 : 1
   name        = local.lacework_audit_policy_name_b

--- a/main.tf
+++ b/main.tf
@@ -140,7 +140,8 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
-`  statement {
+
+  statement {
     sid = "STATES"
     actions = ["states:ListTagsForResource"]
     resources = ["*"]
@@ -241,7 +242,7 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     resources = ["*"]
   }
 
-    statement {
+  statement {
     sid = "KINESISVIDEO"
     actions = ["kinesisvideo:GetSignalingChannelEndpoint",
       "kinesisvideo:GetDataEndpoint",

--- a/main.tf
+++ b/main.tf
@@ -274,7 +274,9 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   }
 }
 
-
+# AWS iam allows only 6144 characters in a single policy
+# We've come to a point where there are too many actions in a single policy which is causing the policy to exceed the limit
+# So we needed a new policy to accommodate the overflow of actions, thus we added this new policy "lacework_audit_policy_b"
 data "aws_iam_policy_document" "lacework_audit_policy_b" {
   count   = var.use_existing_iam_role_policy ? 0 : 1
   version = "2012-10-17"


### PR DESCRIPTION
## Summary

AWS iam policy can only have up to 6144 chars. We need another policy to maintain the new services' permissions.
Modified terraform to have 2 policies created and attach to the same role.
Added permission for FIS, codeartifact.
Added tag call permission for SES, backup and AMP
Adding permission for compute-optimizer, and kinesisvideos

## How did you test this change?

Tested in DEV integration.
https://docs.google.com/document/d/1rkfXAQUaA32_IShki6mTmf2aZF4HRiMSGX6_-I4pf8w/edit?userstoinvite=ljohnny@fortinet.com&sharingaction=manageaccess&role=writer&tab=t.0

## Issue

https://lacework.atlassian.net/browse/RAIN-94239
