### PR TITLE
feat(RAIN-94335): Adding permission for terraform version 0.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 ## Lacework Audit Policy
 Release for 0.19.0(Feb 2025):
 Terraform changes to add a second policy and its attachment under the same role.(This changes is to bypass the 6144 chars limit for one policy)
-Add permissions for kinesisvideo, amp, appstream, personalize, codeartifact, fis; Add missing permission for services ses, backup,
-Add permissions for future services to come: memoryDB, resource groups, qbusiness, servicecatalogappregistry, oam, clouddirectory, optimizationhub, budgets,billingconsole
+Add permissions for kinesisvideo, amp, appstream, personalize, codeartifact, fis; Add missing permission for services ses, backup
+Add permissions for future services to come: memoryDB, resource groups, qbusiness, qapps, qconnect, servicecatalogappregistry, oam, clouddirectory, optimizationhub, budgets,billingconsole
 
 The audit policy is comprised of the following permissions:
 
@@ -259,6 +259,40 @@ The audit policy is comprised of the following permissions:
 |                            | qbusiness:GetWebExperience                              |           |
 |                            | qbusiness:ListPluginTypeMetadata                        |           |
 |                            | qbusiness:ListPluginTypeActions                         |           |
+| QAPPS                      | qapps:DescribeQAppPermissions                           | *         |
+|                            | qapps:GetLibraryItem                                    |           |
+|                            | qapps:GetQApp                                           |           |
+|                            | qapps:GetQAppSession                                    |           |
+|                            | qapps:GetQAppSessionMetadata                            |           |
+|                            | qapps:ListCategories                                    |           |
+|                            | qapps:ListLibraryItems                                  |           |
+|                            | qapps:ListQAppSessionData                               |           |
+|                            | qapps:ListQApps                                         |           |
+|                            | qapps:ListTagsForResource                               |           |
+| QCONNECT                   | wisdom:GetAIAgent                                       | *         |
+|                            | wisdom:GetAIGuardrail                                   |           |
+|                            | wisdom:GetAIPrompt                                      |           |
+|                            | wisdom:GetContent                                       |           |
+|                            | wisdom:GetImportJob                                     |           |
+|                            | wisdom:GetKnowledgeBase                                 |           |
+|                            | wisdom:GetMessageTemplate                               |           |
+|                            | wisdom:GetQuickResponse                                 |           |
+|                            | wisdom:ListAIAgentVersions                              |           |
+|                            | wisdom:ListAIAgents                                     |           |
+|                            | wisdom:ListAIGuardrailVersions                          |           |
+|                            | wisdom:ListAIGuardrails                                 |           |
+|                            | wisdom:ListAIPromptVersions                             |           |
+|                            | wisdom:ListAIPrompts                                    |           |
+|                            | wisdom:ListAssistantAssociations                        |           |
+|                            | wisdom:ListAssistants                                   |           |
+|                            | wisdom:ListContentAssociations                          |           |
+|                            | wisdom:ListContents                                     |           |
+|                            | wisdom:ListImportJobs                                   |           |
+|                            | wisdom:ListKnowledgeBases                               |           |
+|                            | wisdom:ListMessageTemplateVersions                      |           |
+|                            | wisdom:ListMessageTemplates                             |           |
+|                            | wisdom:ListQuickResponses                               |           |
+|                            | wisdom:ListTagsForResource                              |           |
 | RESOURCEGROUPS             | resource-groups:ListGroups                              | *         |
 |                            | resource-groups:GetGroupQuery                           |           |
 |                            | resource-groups:GetGroupConfiguration                   |           |

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ The audit policy is comprised of the following permissions:
 |                            | ses:ListRecommendations                                 |           |
 |                            | ses:ListSuppressedDestinations                          |           |
 |                            | ses:GetSuppressedDestination                            |           |
+|                            | ses:ListTagsForResource                                 |           |
 | BACKUP                     | backup:ListBackupJobs                                   | *         |
 |                            | backup:DescribeBackupJob                                |           |
 |                            | backup:ListBackupPlanTemplates                          |           |
@@ -168,6 +169,7 @@ The audit policy is comprised of the following permissions:
 |                            | backup:ListRecoveryPointsByResource                     |           |
 |                            | backup:ListReportPlans                                  |           |
 |                            | backup:ListRestoreJobs                                  |           |
+|                            | backup:ListTags                                         |           |
 | COGNITO-IDP                | cognito-idp:GetSigningCertificate                       |           |
 |                            | cognito-idp:GetCSVHeader                                |           |
 |                            | cognito-idp:GetUserPoolMfaConfig                        |           |
@@ -198,6 +200,7 @@ The audit policy is comprised of the following permissions:
 |                            | aps:DescribeWorkspace                                   |           |
 |                            | aps:ListRuleGroupsNamespaces                            |           |
 |                            | aps:DescribeRuleGroupsNamespace                         |           |
+|                            | aps:ListTagsForResource                                 |           |
 | APPSTREAM                  | appstream:Describe*                                     |           |
 |                            | appstream:List*                                         |           |
 | PERSONALIZE                | personalize:Describe*                                   |           |
@@ -215,6 +218,7 @@ The audit policy is comprised of the following permissions:
 |                            | codeartifact:ListPackageVersionDependencies             |           |
 |                            | codeartifact:ListPackageVersionAssets                   |           |
 |                            | codeartifact:GetPackageVersionAsset                     |           |
+|                            | codeartifact:ListTagsForResource                        |           |
 | FIS                        | fis:ListActions                                         | *         |
 |                            | fis:GetAction                                           |           |
 |                            | fis:ListExperimentTemplates                             |           |
@@ -223,3 +227,95 @@ The audit policy is comprised of the following permissions:
 |                            | fis:ListExperiments                                     |           |
 |                            | fis:GetExperiment                                       |           |
 |                            | fis:ListExperimentResolvedTargets                       |           |
+| MEMORYDB                   | memorydb:DescribeMultiRegionClusters                    | *         |
+|                            | memorydb:DescribeSnapshots                              |           |
+|                            | memorydb:DescribeSubnetGroups                           |           |
+|                            | memorydb:DescribeParameterGroups                        |           |
+|                            | memorydb:DescribeParameters                             |           |
+|                            | memorydb:DescribeUsers                                  |           |
+|                            | memorydb:DescribeACLs                                   |           |
+|                            | memorydb:DescribeServiceUpdates                         |           |
+|                            | memorydb:DescribeEngineVersions                         |           |
+|                            | memorydb:DescribeReservedNodes                          |           |
+|                            | memorydb:DescribeReservedNodesOfferings                 |           |
+|                            | memorydb:ListTags                                       |           |
+|                            | memorydb:ListAllowedNodeTypeUpdates                     |           |
+|                            | memorydb:ListAllowedMultiRegionClusterUpdates           |           |
+| QBUSINESS                  | qbusiness:GetApplication                                | *         |
+|                            | qbusiness:GetChatControlsConfiguration                  |           |
+|                            | qbusiness:GetPolicy                                     |           |
+|                            | qbusiness:ListAttachments                               |           |
+|                            | qbusiness:ListConversations                             |           |
+|                            | qbusiness:ListMessages                                  |           |
+|                            | qbusiness:ListDataAccessors                             |           |
+|                            | qbusiness:GetDataAccessor                               |           |
+|                            | qbusiness:GetIndex                                      |           |
+|                            | qbusiness:GetDataSource                                 |           |
+|                            | qbusiness:GetPlugin                                     |           |
+|                            | qbusiness:ListPluginActions                             |           |
+|                            | qbusiness:GetRetriever                                  |           |
+|                            | qbusiness:GetWebExperience                              |           |
+|                            | qbusiness:ListPluginTypeMetadata                        |           |
+|                            | qbusiness:ListPluginTypeActions                         |           |
+| RESOURCEGROUPS             | resource-groups:ListGroups                              | *         |
+|                            | resource-groups:GetGroupQuery                           |           |
+|                            | resource-groups:GetGroupConfiguration                   |           |
+| SERVICECATALOGAPPREGISTRY  | servicecatalog:GetApplication                           | *         |
+|                            | servicecatalog:ListApplications                         |           |
+|                            | servicecatalog:GetAssociatedResource                    |           |
+|                            | servicecatalog:ListAssociatedResources                  |           |
+|                            | servicecatalog:ListAssociatedAttributeGroups            |           |
+|                            | servicecatalog:GetAttributeGroup                        |           |
+|                            | servicecatalog:ListAttributeGroups                      |           |
+|                            | servicecatalog:ListTagsForResource                      |           |
+|                            | servicecatalog:ListAttributeGroupsForApplication        |           |
+|                            | servicecatalog:GetConfiguration                         |           |
+| OAM                        | oam:GetLink                                             | *         |
+|                            | oam:GetSink                                             |           |
+|                            | oam:GetSinkPolicy                                       |           |
+|                            | oam:ListAttachedLinks                                   |           |
+|                            | oam:ListLinks                                           |           |
+|                            | oam:ListSinks                                           |           |
+| CLOUDDIRECTORY             | clouddirectory:GetAppliedSchemaVersion                  | *         |
+|                            | clouddirectory:GetDirectory                             |           |
+|                            | clouddirectory:GetFacet                                 |           |
+|                            | clouddirectory:GetLinkAttributes                        |           |
+|                            | clouddirectory:GetObjectAttributes                      |           |
+|                            | clouddirectory:GetObjectInformation                     |           |
+|                            | clouddirectory:GetSchemaAsJson                          |           |
+|                            | clouddirectory:GetTypedLinkFacetInformation             |           |
+|                            | clouddirectory:ListAppliedSchemaArns                    |           |
+|                            | clouddirectory:ListAttachedIndices                      |           |
+|                            | clouddirectory:ListDevelopmentSchemaArns                |           |
+|                            | clouddirectory:ListFacetAttributes                      |           |
+|                            | clouddirectory:ListFacetNames                           |           |
+|                            | clouddirectory:ListIncomingTypedLinks                   |           |
+|                            | clouddirectory:ListIndex                                |           |
+|                            | clouddirectory:ListManagedSchemaArns                    |           |
+|                            | clouddirectory:ListObjectAttributes                     |           |
+|                            | clouddirectory:ListObjectChildren                       |           |
+|                            | clouddirectory:ListObjectParentPaths                    |           |
+|                            | clouddirectory:ListObjectParents                        |           |
+|                            | clouddirectory:ListObjectPolicies                       |           |
+|                            | clouddirectory:ListOutgoingTypedLinks                   |           |
+|                            | clouddirectory:ListPolicyAttachments                    |           |
+|                            | clouddirectory:ListPublishedSchemaArns                  |           |
+|                            | clouddirectory:ListTagsForResource                      |           |
+|                            | clouddirectory:ListTypedLinkFacetAttributes             |           |
+|                            | clouddirectory:ListTypedLinkFacetNames                  |           |
+| COSTOPTIMIZATIONHUB        | cost-optimization-hub:GetPreferences                    | *         |
+|                            | cost-optimization-hub:GetRecommendation                 |           |
+|                            | cost-optimization-hub:ListEnrollmentStatuses            |           |
+|                            | cost-optimization-hub:ListRecommendationSummaries       |           |
+|                            | cost-optimization-hub:ListRecommendations               |           |
+| BUDGETS                    | budgets:DescribeBudgetAction                            | *         |
+|                            | budgets:DescribeBudgetActionHistories                   |           |
+|                            | budgets:DescribeBudgetActionsForAccount                 |           |
+|                            | budgets:DescribeBudgetActionsForBudget                  |           |
+|                            | budgets:ListTagsForResource                             |           |
+|                            | budgets:ViewBudget                                      |           |
+| BILLINGCONSOLE             | aws-portal:GetConsoleActionSetEnforced                  | *         |
+|                            | aws-portal :ViewAccount                                 |           |
+|                            | aws-portal :ViewBilling                                 |           |
+|                            | aws-portal :ViewPaymentMethods                          |           |
+|                            | aws-portal :ViewUsage                                   |           |

--- a/README.md
+++ b/README.md
@@ -77,9 +77,11 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 <!-- END_TF_DOCS -->
 
 ## Lacework Audit Policy
+Release for 0.19.0(Feb 2025):
+Terraform changes to add a second policy and its attachment under the same role.(This changes is to bypass the 6144 chars limit for one policy)
+Add permissions for kinesisvideo, amp, appstream, personalize, codeartifact, fis; Add missing permission for services ses, backup,
+Add permissions for future services to come: memoryDB, resource groups, qbusiness, servicecatalogappregistry, oam, clouddirectory, optimizationhub, budgets,billingconsole
 
-The Lacework audit policy extends the SecurityAudit policy to facilitate the reading of additional configuration resources.
-As of 1/22/2025, we have exceeded the limit of 6144 characters for a single policy, thus every service starting with KINESISVIDEO are in a new policy: lwaudit-policy-${random_id.uniq.hex}-2025-1
 The audit policy is comprised of the following permissions:
 
 | sid                        | actions                                                 | resources |

--- a/main.tf
+++ b/main.tf
@@ -241,15 +241,6 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
     ]
     resources = ["*"]
   }
-}
-
-# AWS iam allows only 6144 characters in a single policy
-# We've come to a point where there are too many actions in a single policy which is causing the policy to exceed the limit
-# So we needed a new policy to accommodate the overflow of actions, thus we added this new policy "lacework_audit_policy_2025_1"
-# Which representing the first new policy in 2025
-data "aws_iam_policy_document" "lacework_audit_policy_2025_1" {
-  count   = var.use_existing_iam_role_policy ? 0 : 1
-  version = "2012-10-17"
 
   statement {
     sid = "KINESISVIDEO"
@@ -274,6 +265,15 @@ data "aws_iam_policy_document" "lacework_audit_policy_2025_1" {
     ]
     resources = ["*"]
   }
+}
+
+# AWS iam allows only 6144 characters in a single policy
+# We've come to a point where there are too many actions in a single policy which is causing the policy to exceed the limit
+# So we needed a new policy to accommodate the overflow of actions, thus we added this new policy "lacework_audit_policy_2025_1"
+# Which representing the first new policy in 2025
+data "aws_iam_policy_document" "lacework_audit_policy_2025_1" {
+  count   = var.use_existing_iam_role_policy ? 0 : 1
+  version = "2012-10-17"
 
   statement {
     sid = "APPSTREAM"

--- a/main.tf
+++ b/main.tf
@@ -369,6 +369,52 @@ data "aws_iam_policy_document" "lacework_audit_policy_2025_1" {
   }
 
   statement {
+    sid = "QAPPS"
+    actions = ["qapps:DescribeQAppPermissions",
+      "qapps:GetLibraryItem",
+      "qapps:GetQApp",
+      "qapps:GetQAppSession",
+      "qapps:GetQAppSessionMetadata",
+      "qapps:ListCategories",
+      "qapps:ListLibraryItems",
+      "qapps:ListQAppSessionData",
+      "qapps:ListQApps",
+      "qapps:ListTagsForResource",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "QCONNECT"
+    actions = ["wisdom:GetAIAgent",
+      "wisdom:GetAIGuardrail",
+      "wisdom:GetAIPrompt",
+      "wisdom:GetContent",
+      "wisdom:GetImportJob",
+      "wisdom:GetKnowledgeBase",
+      "wisdom:GetMessageTemplate",
+      "wisdom:GetQuickResponse",
+      "wisdom:ListAIAgentVersions",
+      "wisdom:ListAIAgents",
+      "wisdom:ListAIGuardrailVersions",
+      "wisdom:ListAIGuardrails",
+      "wisdom:ListAIPromptVersions",
+      "wisdom:ListAIPrompts",
+      "wisdom:ListAssistantAssociations",
+      "wisdom:ListAssistants",
+      "wisdom:ListContentAssociations",
+      "wisdom:ListContents",
+      "wisdom:ListImportJobs",
+      "wisdom:ListKnowledgeBases",
+      "wisdom:ListMessageTemplateVersions",
+      "wisdom:ListMessageTemplates",
+      "wisdom:ListQuickResponses",
+      "wisdom:ListTagsForResource"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
     sid = "RESOURCEGROUPS"
     actions = ["resource-groups:ListGroups",
       "resource-groups:GetGroupQuery",

--- a/main.tf
+++ b/main.tf
@@ -252,40 +252,6 @@ data "aws_iam_policy_document" "lacework_audit_policy_2025_1" {
   version = "2012-10-17"
 
   statement {
-    sid = "CODEARTIFACT"
-    actions = ["codeartifact:ListDomains",
-      "codeartifact:DescribeDomain",
-      "codeartifact:DescribeRepository",
-      "codeartifact:ListPackages",
-      "codeartifact:GetRepositoryEndpoint",
-      "codeartifact:DescribePackage",
-      "codeartifact:ListPackageVersions",
-      "codeartifact:DescribePackageVersion",
-      "codeartifact:GetPackageVersionReadme",
-      "codeartifact:ListPackageVersionDependencies",
-      "codeartifact:ListPackageVersionAssets",
-      "codeartifact:GetPackageVersionAsset",
-      "codeartifact:ListTagsForResource",
-    ]
-    resources = ["*"]
-  }
-
-  statement {
-    sid = "FIS"
-    actions = ["fis:ListActions",
-        "fis:GetAction",
-        "fis:ListExperimentTemplates",
-        "fis:GetExperimentTemplate",
-        "fis:ListTargetAccountConfigurations",
-        "fis:ListExperiments",
-        "fis:GetExperiment",
-        "fis:ListExperimentResolvedTargets",
-        "fis:ListTagsForResource",
-    ]
-    resources = ["*"]
-  }
-
-  statement {
     sid = "KINESISVIDEO"
     actions = ["kinesisvideo:GetSignalingChannelEndpoint",
       "kinesisvideo:GetDataEndpoint",
@@ -322,6 +288,186 @@ data "aws_iam_policy_document" "lacework_audit_policy_2025_1" {
     actions = ["personalize:Describe*",
       "personalize:List*",
       "personalize:GetSolutionMetrics",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "CODEARTIFACT"
+    actions = ["codeartifact:ListDomains",
+      "codeartifact:DescribeDomain",
+      "codeartifact:DescribeRepository",
+      "codeartifact:ListPackages",
+      "codeartifact:GetRepositoryEndpoint",
+      "codeartifact:DescribePackage",
+      "codeartifact:ListPackageVersions",
+      "codeartifact:DescribePackageVersion",
+      "codeartifact:GetPackageVersionReadme",
+      "codeartifact:ListPackageVersionDependencies",
+      "codeartifact:ListPackageVersionAssets",
+      "codeartifact:GetPackageVersionAsset",
+      "codeartifact:ListTagsForResource",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "FIS"
+    actions = ["fis:ListActions",
+        "fis:GetAction",
+        "fis:ListExperimentTemplates",
+        "fis:GetExperimentTemplate",
+        "fis:ListTargetAccountConfigurations",
+        "fis:ListExperiments",
+        "fis:GetExperiment",
+        "fis:ListExperimentResolvedTargets",
+        "fis:ListTagsForResource",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "MEMORYDB"
+    actions = ["memorydb:DescribeMultiRegionClusters",
+      "memorydb:DescribeSnapshots",
+      "memorydb:DescribeSubnetGroups",
+      "memorydb:DescribeParameterGroups",
+      "memorydb:DescribeParameters",
+      "memorydb:DescribeUsers",
+      "memorydb:DescribeACLs",
+      "memorydb:DescribeServiceUpdates",
+      "memorydb:DescribeEngineVersions",
+      "memorydb:DescribeReservedNodes",
+      "memorydb:DescribeReservedNodesOfferings",
+      "memorydb:ListTags",
+      "memorydb:ListAllowedNodeTypeUpdates",
+      "memorydb:ListAllowedMultiRegionClusterUpdates",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "QBUSINESS"
+    actions = ["qbusiness:GetApplication",
+      "qbusiness:GetChatControlsConfiguration",
+      "qbusiness:GetPolicy",
+      "qbusiness:ListAttachments",
+      "qbusiness:ListConversations",
+      "qbusiness:ListMessages",
+      "qbusiness:ListDataAccessors",
+      "qbusiness:GetDataAccessor",
+      "qbusiness:GetIndex",
+      "qbusiness:GetDataSource",
+      "qbusiness:GetPlugin",
+      "qbusiness:ListPluginActions",
+      "qbusiness:GetRetriever",
+      "qbusiness:GetWebExperience",
+      "qbusiness:ListPluginTypeMetadata",
+      "qbusiness:ListPluginTypeActions",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "RESOURCEGROUPS"
+    actions = ["resource-groups:ListGroups",
+      "resource-groups:GetGroupQuery",
+      "resource-groups:GetGroupConfiguration",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "SERVICECATALOGAPPREGISTRY"
+    actions = ["servicecatalog:GetApplication",
+      "servicecatalog:ListApplications",
+      "servicecatalog:GetAssociatedResource",
+      "servicecatalog:ListAssociatedResources",
+      "servicecatalog:ListAssociatedAttributeGroups",
+      "servicecatalog:GetAttributeGroup",
+      "servicecatalog:ListAttributeGroups",
+      "servicecatalog:ListTagsForResource",
+      "servicecatalog:ListAttributeGroupsForApplication",
+      "servicecatalog:GetConfiguration"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "OAM"
+    actions = ["oam:GetLink",
+      "oam:GetSink",
+      "oam:GetSinkPolicy",
+      "oam:ListAttachedLinks",
+      "oam:ListLinks",
+      "oam:ListSinks",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "CLOUDDIRECTORY"
+    actions = ["clouddirectory:GetAppliedSchemaVersion",
+      "clouddirectory:GetDirectory",
+      "clouddirectory:GetFacet",
+      "clouddirectory:GetLinkAttributes",
+      "clouddirectory:GetObjectAttributes",
+      "clouddirectory:GetObjectInformation",
+      "clouddirectory:GetSchemaAsJson",
+      "clouddirectory:GetTypedLinkFacetInformation",
+      "clouddirectory:ListAppliedSchemaArns",
+      "clouddirectory:ListAttachedIndices",
+      "clouddirectory:ListDevelopmentSchemaArns",
+      "clouddirectory:ListFacetAttributes",
+      "clouddirectory:ListFacetNames",
+      "clouddirectory:ListIncomingTypedLinks",
+      "clouddirectory:ListIndex",
+      "clouddirectory:ListManagedSchemaArns",
+      "clouddirectory:ListObjectAttributes",
+      "clouddirectory:ListObjectChildren",
+      "clouddirectory:ListObjectParentPaths",
+      "clouddirectory:ListObjectParents",
+      "clouddirectory:ListObjectPolicies",
+      "clouddirectory:ListOutgoingTypedLinks",
+      "clouddirectory:ListPolicyAttachments",
+      "clouddirectory:ListPublishedSchemaArns",
+      "clouddirectory:ListTagsForResource",
+      "clouddirectory:ListTypedLinkFacetAttributes",
+      "clouddirectory:ListTypedLinkFacetNames",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "COSTOPTIMIZATIONHUB"
+    actions = ["cost-optimization-hub:GetPreferences",
+      "cost-optimization-hub:GetRecommendation",
+      "cost-optimization-hub:ListEnrollmentStatuses",
+      "cost-optimization-hub:ListRecommendationSummaries",
+      "cost-optimization-hub:ListRecommendations",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "BUDGETS"
+    actions = ["budgets:DescribeBudgetAction",
+      "budgets:DescribeBudgetActionHistories",
+      "budgets:DescribeBudgetActionsForAccount",
+      "budgets:DescribeBudgetActionsForBudget",
+      "budgets:ListTagsForResource",
+      "budgets:ViewBudget",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "BILLINGCONSOLE"
+    actions = ["aws-portal:GetConsoleActionSetEnforced",
+      "aws-portal:ViewAccount",
+      "aws-portal:ViewBilling",
+      "aws-portal:ViewPaymentMethods",
+      "aws-portal:ViewUsage",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Summary

Adding readonly permissions for services:
  memoryDB
  qbusiness
  qconnect
  qapps
  resourcegroups
  servicecatalogappregistry
  oam
  clouddirectory
  optimizationhub
  budgets
  billingconsole

## How did you test this change?

Applied to dev aws account and tested the permission in the iam policy simulator
![image](https://github.com/user-attachments/assets/92b07254-ac4a-4888-b008-36945bcc94eb)



## Issue
https://lacework.atlassian.net/browse/RAIN-94335