### PR TITLE
chore(RAIN-94454): Remove two redundant policies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,12 +38,6 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
   version = "2012-10-17"
 
   statement {
-    sid       = "GetEbsEncryptionByDefault"
-    actions   = ["ec2:GetEbsEncryptionByDefault"]
-    resources = ["*"]
-  }
-
-  statement {
     sid       = "GetBucketPublicAccessBlock"
     actions   = ["s3:GetBucketPublicAccessBlock"]
     resources = ["*"]
@@ -199,7 +193,6 @@ data "aws_iam_policy_document" "lacework_audit_policy" {
       "backup:ListRecoveryPointsByResource",
       "backup:ListReportPlans",
       "backup:ListRestoreJobs",
-      "backup:ListTags",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## Summary

Some permission in our custom policy are overlapping with security audit policy, we need to remove the redundant ones to free up space.

## How did you test this change?

Tested in our dev env and ran.

## Issue

https://lacework.atlassian.net/browse/RAIN-94454
