### PR TITLE
feat(RAIN-94565): Added 11 services for TF permissions 20.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,62 @@ The audit policy is comprised of the following permissions:
 |                            | budgets:ListTagsForResource                             |           |
 |                            | budgets:ViewBudget                                      |           |
 | BILLINGCONSOLE             | aws-portal:GetConsoleActionSetEnforced                  | *         |
-|                            | aws-portal :ViewAccount                                 |           |
-|                            | aws-portal :ViewBilling                                 |           |
-|                            | aws-portal :ViewPaymentMethods                          |           |
-|                            | aws-portal :ViewUsage                                   |           |
+|                            | aws-portal:ViewAccount                                  |           |
+|                            | aws-portal:ViewBilling                                  |           |
+|                            | aws-portal:ViewPaymentMethods                           |           |
+|                            | aws-portal:ViewUsage                                    |           |
+| ACM-PCA                    | acm-pca:GetCertificateAuthorityCertificate              | *         |
+|                            | acm-pca:GetCertificateAuthorityCertificate              | *         |
+|                            | acm-pca:GetCertificateAuthorityCsr                      |           |
+| APPCONFIG                  | appconfig:GetConfigurationProfile                       | *         |
+|                            | appconfig:GetDeploymentStrategy                         |           |
+|                            | appconfig:GetExtension                                  |           |
+|                            | appconfig:GetExtensionAssociation                       |           |
+|                            | appconfig:GetHostedConfigurationVersion                 |           |
+|                            | appconfig:ListApplications                              |           |
+|                            | appconfig:ListConfigurationProfiles                     |           |
+|                            | appconfig:ListDeployments                               |           |
+|                            | appconfig:ListDeploymentStrategies                      |           |
+|                            | appconfig:ListEnvironments                              |           |
+|                            | appconfig:ListExtensionAssociations                     |           |
+|                            | appconfig:ListExtensions                                |           |
+|                            | appconfig:ListHostedConfigurationVersions               |           |
+|                            | appconfig:ListTagsForResource                           |           |
+| APPFLOW                    | appflow:DescribeConnector                               | *         |
+|                            | appflow:DescribeConnectorEntity                         |           |
+|                            | appflow:DescribeConnectorFields                         |           |
+|                            | appflow:DescribeConnectorProfiles                       |           |
+|                            | appflow:DescribeConnectors                              |           |
+|                            | appflow:DescribeFlow                                    |           |
+|                            | appflow:DescribeFlowExecution                           |           |
+|                            | appflow:DescribeFlowExecutionRecords                    |           |
+|                            | appflow:DescribeFlows                                   |           |
+|                            | appflow:ListConnectorEntities                           |           |
+|                            | appflow:ListConnectorFields                             |           |
+|                            | appflow:ListConnectors                                  |           |
+|                            | appflow:ListFlows                                       |           |
+|                            | appflow:ListTagsForResource                             |           |
+| DYNAMODB                   | dynamodb:DescribeContributorInsights                    | *         |
+|                            | dynamodb:GetResourcePolicy                              |           |
+| EBS                        | ebs:GetSnapshotBlock                                    | *         |
+|                            | ebs:ListChangedBlocks                                   |           |
+|                            | ebs:ListSnapshotBlocks                                  |           |
+| FREETIER                   | freetier:GetFreeTierUsage                               | *         |
+| LAKEFORMATION              | lakeformation:DescribeLakeFormationIdentityCenterConfiguration | *  |
+|                            | lakeformation:GetDataLakePrincipal                      |           |
+|                            | lakeformation:GetDataLakeSettings                       |           |
+|                            | lakeformation:GetEffectivePermissionsForPath            |           |
+|                            | lakeformation:GetTableObjects                           |           |
+|                            | lakeformation:ListDataCellsFilter                       |           |
+|                            | lakeformation:ListPermissions                           |           |
+|                            | lakeformation:ListResources                             |           |
+|                            | lakeformation:ListTableStorageOptimizers                |           |
+|                            | lakeformation:ListTransactions                          |           |
+| LAMBDA                     | lambda:GetFunction                                      | *         |
+|                            | lambda:GetFunctionCodeSigningConfig                     |           |
+| SCHEDULER                  | scheduler:GetSchedule                                   | *         |
+|                            | scheduler:GetScheduleGroup                              |           |
+|                            | scheduler:ListScheduleGroups                            |           |
+|                            | scheduler:ListSchedules                                 |           |
+|                            | scheduler:ListTagsForResource                           |           |
+| SCHEMAS                    | schemas:GetCodeBindingSource                            | *         |

--- a/README.md
+++ b/README.md
@@ -39,14 +39,17 @@ Terraform module for configuring an integration with Lacework and AWS for cloud 
 |------|------|
 | [aws_iam_policy.lacework_audit_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.lacework_audit_policy_2025_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.lacework_audit_policy_2025_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role_policy_attachment.lacework_audit_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lacework_audit_policy_attachment_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lacework_audit_policy_attachment_c](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.security_audit_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [lacework_integration_aws_cfg.default](https://registry.terraform.io/providers/lacework/lacework/latest/docs/resources/integration_aws_cfg) | resource |
 | [random_id.uniq](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [time_sleep.wait_time](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_iam_policy_document.lacework_audit_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lacework_audit_policy_2025_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lacework_audit_policy_2025_2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [lacework_metric_module.lwmetrics](https://registry.terraform.io/providers/lacework/lacework/latest/docs/data-sources/metric_module) | data source |
 
 ## Inputs

--- a/README.md
+++ b/README.md
@@ -375,24 +375,16 @@ The audit policy is comprised of the following permissions:
 |                            | appconfig:ListExtensions                                |           |
 |                            | appconfig:ListHostedConfigurationVersions               |           |
 |                            | appconfig:ListTagsForResource                           |           |
-| APPFLOW                    | appflow:DescribeConnector                               | *         |
-|                            | appflow:DescribeConnectorEntity                         |           |
-|                            | appflow:DescribeConnectorFields                         |           |
+| APPFLOW                    | appflow:DescribeConnectorEntity                         | *         |
 |                            | appflow:DescribeConnectorProfiles                       |           |
 |                            | appflow:DescribeConnectors                              |           |
 |                            | appflow:DescribeFlow                                    |           |
-|                            | appflow:DescribeFlowExecution                           |           |
 |                            | appflow:DescribeFlowExecutionRecords                    |           |
-|                            | appflow:DescribeFlows                                   |           |
 |                            | appflow:ListConnectorEntities                           |           |
-|                            | appflow:ListConnectorFields                             |           |
 |                            | appflow:ListConnectors                                  |           |
-|                            | appflow:ListFlows                                       |           |
-|                            | appflow:ListTagsForResource                             |           |
 | DYNAMODB                   | dynamodb:DescribeContributorInsights                    | *         |
 |                            | dynamodb:GetResourcePolicy                              |           |
 | EBS                        | ebs:GetSnapshotBlock                                    | *         |
-|                            | ebs:ListChangedBlocks                                   |           |
 |                            | ebs:ListSnapshotBlocks                                  |           |
 | FREETIER                   | freetier:GetFreeTierUsage                               | *         |
 | LAKEFORMATION              | lakeformation:DescribeLakeFormationIdentityCenterConfiguration | *  |

--- a/README.md
+++ b/README.md
@@ -413,3 +413,24 @@ The audit policy is comprised of the following permissions:
 |                            | scheduler:ListSchedules                                 |           |
 |                            | scheduler:ListTagsForResource                           |           |
 | SCHEMAS                    | schemas:GetCodeBindingSource                            | *         |
+| DATASYNC                   | datasync:DescribeTaskExecution                          | *         |
+|                            | datasync:DescribeLocationEfs                            |           |
+|                            | datasync:ListAgents                                     |           |
+|                            | datasync:ListLocations                                  |           |
+|                            | datasync:ListTaskExecutions                             |           |
+|                            | datasync:ListStorageSystems                             |           |
+|                            | datasync:DescribeLocationSmb                            |           |
+|                            | datasync:DescribeAgent                                  |           |
+|                            | datasync:DescribeLocationFsxWindows                     |           |
+|                            | datasync:DescribeTask                                   |           |
+|                            | datasync:DescribeLocationS3                             |           |
+|                            | datasync:DescribeDiscoveryJob                           |           |
+|                            | datasync:DescribeLocationObjectStorage                  |           |
+|                            | datasync:DescribeStorageSystem                          |           |
+|                            | datasync:DescribeLocationAzureBlob                      |           |
+|                            | datasync:ListTagsForResource                            |           |
+|                            | datasync:ListTasks                                      |           |
+|                            | datasync:DescribeLocationHdfs                           |           |
+|                            | datasync:DescribeLocationFsxLustre                      |           |
+|                            | datasync:ListDiscoveryJobs                              |           |
+|                            | datasync:DescribeLocationNfs                            |           |

--- a/main.tf
+++ b/main.tf
@@ -556,20 +556,13 @@ data "aws_iam_policy_document" "lacework_audit_policy_2025_2" {
 
   statement {
     sid = "APPFLOW"
-    actions = ["appflow:DescribeConnector",
-      "appflow:DescribeConnectorEntity",
-      "appflow:DescribeConnectorFields",
+    actions = ["appflow:DescribeConnectorEntity",
       "appflow:DescribeConnectorProfiles",
       "appflow:DescribeConnectors",
       "appflow:DescribeFlow",
-      "appflow:DescribeFlowExecution",
       "appflow:DescribeFlowExecutionRecords",
-      "appflow:DescribeFlows",
       "appflow:ListConnectorEntities",
-      "appflow:ListConnectorFields",
       "appflow:ListConnectors",
-      "appflow:ListFlows",
-      "appflow:ListTagsForResource",
     ]
     resources = ["*"]
   }
@@ -585,7 +578,6 @@ data "aws_iam_policy_document" "lacework_audit_policy_2025_2" {
   statement {
     sid = "EBS"
     actions = ["ebs:GetSnapshotBlock",
-      "ebs:ListChangedBlocks",
       "ebs:ListSnapshotBlocks",
     ]
     resources = ["*"]

--- a/main.tf
+++ b/main.tf
@@ -631,6 +631,33 @@ data "aws_iam_policy_document" "lacework_audit_policy_2025_2" {
     actions = ["schemas:GetCodeBindingSource"]
     resources = ["*"]
   }
+
+    statement {
+    sid = "DATASYNC"
+    actions = ["datasync:DescribeTaskExecution",
+      "datasync:DescribeLocationEfs",
+      "datasync:ListAgents",
+      "datasync:ListLocations",
+      "datasync:ListTaskExecutions",
+      "datasync:ListStorageSystems",
+      "datasync:DescribeLocationSmb",
+      "datasync:DescribeAgent",
+      "datasync:DescribeLocationFsxWindows",
+      "datasync:DescribeTask",
+      "datasync:DescribeLocationS3",
+      "datasync:DescribeDiscoveryJob",
+      "datasync:DescribeLocationObjectStorage",
+      "datasync:DescribeStorageSystem",
+      "datasync:DescribeLocationAzureBlob",
+      "datasync:ListTagsForResource",
+      "datasync:ListTasks",
+      "datasync:DescribeLocationHdfs",
+      "datasync:DescribeLocationFsxLustre",
+      "datasync:ListDiscoveryJobs",
+      "datasync:DescribeLocationNfs"
+    ]
+    resources = ["*"]
+  }
 }
 
 resource "aws_iam_policy" "lacework_audit_policy" {

--- a/main.tf
+++ b/main.tf
@@ -632,7 +632,7 @@ data "aws_iam_policy_document" "lacework_audit_policy_2025_2" {
     resources = ["*"]
   }
 
-    statement {
+  statement {
     sid = "DATASYNC"
     actions = ["datasync:DescribeTaskExecution",
       "datasync:DescribeLocationEfs",

--- a/main.tf
+++ b/main.tf
@@ -527,7 +527,7 @@ data "aws_iam_policy_document" "lacework_audit_policy_2025_2" {
   }
 
   statement {
-    sid = "ACM-PCA"
+    sid = "ACMPCA"
     actions = ["acm-pca:GetCertificateAuthorityCertificate",
       "acm-pca:GetCertificateAuthorityCsr",
     ]


### PR DESCRIPTION
## Summary

Adding permissions for upcoming services including:
1. Free Tier
2. ACM-PCA
3. Lambda(partial)
4. Schemas(partial)
5. Scheduler
6. Lakeformation
7. DynamoDB(Partial)
8. Appconfig
9. AppFlow
10. EBS
11. DATASYNC

## How did you test this change?

Testing in DEV account
https://docs.google.com/document/d/1raSa62A7Q1sqbdYhxU2z73OrMVjS7odE995yfnN6NKI/edit?tab=t.0

## Issue

https://lacework.atlassian.net/browse/RAIN-94565
