### PR TITLE
Feat(RAIN-95185): Add AWS Forecast permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -965,6 +965,41 @@ data "aws_iam_policy_document" "lacework_audit_policy_2025_4" {
     ]
      resources = ["*"]
   }
+
+  statement {
+    sid = "FORECAST"
+    actions = ["forecast:DescribeDataset",
+      "forecast:GetAccuracyMetrics",
+      "forecast:DescribeExplainability",
+      "forecast:ListForecastExportJobs",
+      "forecast:ListForecasts",
+      "forecast:DescribeForecast",
+      "forecast:DescribeMonitor",
+      "forecast:ListMonitorEvaluations",
+      "forecast:DescribePredictor",
+      "forecast:ListWhatIfForecasts",
+      "forecast:DescribeDatasetImportJob",
+      "forecast:ListDatasetGroups",
+      "forecast:ListPredictorBacktestExportJobs",
+      "forecast:DescribeExplainabilityExport",
+      "forecast:ListMonitors",
+      "forecast:DescribePredictorBacktestExportJob",
+      "forecast:DescribeDatasetGroup",
+      "forecast:ListWhatIfAnalyses",
+      "forecast:DescribeWhatIfForecastExport",
+      "forecast:DescribeAutoPredictor",
+      "forecast:ListExplainabilities",
+      "forecast:DescribeForecastExportJob",
+      "forecast:DescribeWhatIfForecast",
+      "forecast:DescribeWhatIfAnalysis",
+      "forecast:ListDatasetImportJobs",
+      "forecast:ListExplainabilityExports",
+      "forecast:ListWhatIfForecastExports",
+      "forecast:ListTagsForResource",
+      "forecast:ListPredictors"
+    ]
+    resources = ["*"]
+  }
 }
 
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes.
  Please provide enough information so that others can review your pull request.
  
  Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
--->

## Summary
https://lacework.atlassian.net/browse/RAIN-95185

## How did you test this change?
Manually apply terraform to AWS

## Issue

<!--
  Include the link to a Jira/Github issue
-->
