### PR TITLE
chore: replace-tfsec-with-trivy in ci tests workflow

### DIFF
--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -39,8 +39,7 @@ lint_tests() {
 }
 
 sec_tests() {
-  # TODO: replace with `lacework iac tf-scan tfsec -m MEDIUM`
-  tfsec -m MEDIUM
+  trivy config --severity MEDIUM,HIGH,CRITICAL .
 }
 
 main() {


### PR DESCRIPTION
This replaces tfsec with Trivy, its official successor.
https://github.com/aquasecurity/tfsec?tab=readme-ov-file
https://github.com/aquasecurity/trivy

Issue
Related OSS actions PR: https://github.com/lacework/oss-actions/pull/17