### PR TITLE
chore: add Jira/Github ticket section at top of PR template

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -6,6 +6,12 @@
   Please read the contribution document: https://github.com/lacework/terraform-aws-config/blob/main/CONTRIBUTING.md
 --->
 
+## Jira/Github ticket
+
+<!--
+  Link to the Jira ticket (e.g., https://lacework.atlassian.net/browse/XXX-1234) or GitHub issue
+-->
+
 ## Summary
 
 <!--
@@ -17,10 +23,4 @@
 <!--
   How exactly did you verify that your PR solves the issue you wanted to solve?
   Include any other relevant information such as how to use the new functionality, screenshots, etc.
--->
-
-## Issue
-
-<!--
-  Include the link to a Jira/Github issue
 -->


### PR DESCRIPTION
## Jira/Github ticket

N/A — repo tooling change.

## Summary

Updates `.github/pull-request-template.md`:

- Adds a **Jira/Github ticket** section at the top so contributors surface the associated ticket immediately, above Summary / How did you test.
- Removes the old bottom **Issue** section (now redundant with the top section).

## How did you test this change?

- [x] Markdown renders correctly (visible in this PR's description preview)
- [x] No code/build impact — template-only change